### PR TITLE
chore(post-public-flip): drop private-repo affordances in docs + CI

### DIFF
--- a/.github/workflows/smoke-install.yml
+++ b/.github/workflows/smoke-install.yml
@@ -23,10 +23,11 @@ on:
 permissions:
   contents: read
 
-env:
-  # GITHUB_TOKEN is needed while the repo is private so the install scripts
-  # can authenticate their API + asset downloads. Harmless once public.
-  GH_TOKEN: ${{ github.token }}
+# GH_TOKEN deliberately NOT set at workflow level. The repo is public, so
+# install.sh / install.ps1 should exercise the same anonymous download
+# path that the README tells real users to run. The scripts' GH_TOKEN
+# branch is still code-path-tested via `cargo test` helpers; no need to
+# duplicate it here.
 
 jobs:
   install-sh:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ If your agent is dedicated to Inderes (you use its tools on most turns) or you'r
 curl -sSL https://raw.githubusercontent.com/heikki-laitala/inderes-cli/main/install.sh | bash
 ```
 
-Downloads the latest release binary for your OS+arch into `~/.local/bin/inderes`, verifies SHA-256, and prints a PATH reminder if needed.
+Downloads the latest release binary for your OS+arch into `~/.local/bin/inderes`, verifies SHA-256 against the release's `SHAxxxxSUMS` sidecar, and prints a PATH reminder if needed. No authentication needed — release assets are public.
+
+If you hit GitHub's anonymous rate limit (60/hr) on a shared network, export `GH_TOKEN=$(gh auth token)` before running to use your authenticated 5000/hr quota.
 
 ### Any platform — cargo
 
@@ -48,7 +50,7 @@ Requires Rust 1.82+.
 iwr -useb https://raw.githubusercontent.com/heikki-laitala/inderes-cli/main/install.ps1 | iex
 ```
 
-Installs `inderes.exe` into `%LOCALAPPDATA%\Programs\inderes\bin` and prints a PATH reminder if needed. Verifies SHA-256 before installing.
+Installs `inderes.exe` into `%LOCALAPPDATA%\Programs\inderes\bin` and prints a PATH reminder if needed. Verifies SHA-256 before installing. Set `$env:GH_TOKEN` first only if you're hitting GitHub's anonymous rate limit.
 
 Or download `inderes-x86_64-pc-windows-msvc.zip` from the [latest release](https://github.com/heikki-laitala/inderes-cli/releases/latest) manually.
 

--- a/install.ps1
+++ b/install.ps1
@@ -8,8 +8,11 @@
 #   $env:INDERES_INSTALL_DIR  install directory
 #                             (default: %LOCALAPPDATA%\Programs\inderes\bin)
 #   $env:INDERES_REPO         release source (default: heikki-laitala/inderes-cli)
-#   $env:GH_TOKEN             forwarded as `Authorization: Bearer` on GitHub
-#                             requests — needed when the repo is private.
+#   $env:GH_TOKEN             optional — when set, forwarded as
+#                             `Authorization: Bearer` so GitHub's API calls
+#                             use the 5000/hr authenticated rate limit
+#                             (vs 60/hr anonymous) and private-repo mirrors
+#                             work.
 
 $ErrorActionPreference = "Stop"
 

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,11 @@
 #   INDERES_VERSION=v0.1.0       install a specific tag (default: latest)
 #   INDERES_INSTALL_DIR=~/bin    install directory (default: ~/.local/bin)
 #   INDERES_REPO=owner/repo      release source (default: heikki-laitala/inderes-cli)
-#   GH_TOKEN=<token>             forwarded as `Authorization: Bearer` on GitHub
-#                                requests — needed when the repo is private.
+#   GH_TOKEN=<token>             optional — when set, forwarded as
+#                                `Authorization: Bearer` so GitHub's API calls
+#                                use the 5000/hr authenticated rate limit
+#                                (vs 60/hr anonymous) and private-repo
+#                                mirrors work.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

With the repo now public, the bearer-token scaffolding added while private is no longer part of the happy path. This PR aligns docs + CI with the world users actually live in, without touching any Rust code.

- **`.github/workflows/smoke-install.yml`** — drops the workflow-level \`GH_TOKEN: \${{ github.token }}\` env. Smoke tests now exercise the anonymous \`install.sh\` / \`install.ps1\` path the README points users at. The scripts' \`GH_TOKEN\` branch is still present in the source, just not forced in CI.
- **\`install.sh\` / \`install.ps1\`** — reframes the \`GH_TOKEN\` env var from *"needed when the repo is private"* to *"optional — use the 5000/hr authenticated rate limit on shared networks, or against private-repo mirrors"*. No code-path changes.
- **\`README.md\`** — updates the install one-liners to match (no mandatory \`GH_TOKEN\`; brief note on how to opt into authenticated downloads if hitting anonymous rate limits).

## Test plan

- [x] \`cargo fmt --check\` (no Rust changes, but run for parity)
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --all-targets\` (92 tests, all green)
- [x] \`npx markdownlint-cli2@0.22.1\` (8 files, clean)
- [ ] CI matrix green on Linux/macOS/Windows (runs on PR)
- [ ] Next release's smoke-install run validates anonymous-download path works across all 5 target triples

## Notes

- This is also the first PR exercising the new branch protection rules: code-owner review required + linear history + CI must pass. As the sole code owner, I'll merge via admin bypass once CI is green.
- No version bump — documentation/CI tweak only.