### PR TITLE
release: v2026.4.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "inderes-cli"
-version = "2026.4.24"
+version = "2026.4.25"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inderes-cli"
-version = "2026.4.24"
+version = "2026.4.25"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Heikki Laitala"]


### PR DESCRIPTION
## Summary

Cuts a new calendar-versioned release. No breaking CLI surface changes — same subcommands, same flags, same env vars as \`v2026.4.24\`.

Everything merged since the previous tag rolls up here:

- **IdpConfig centralization** (`oauth.rs`) + `INDERES_IDP_*` env-var overrides for staging/self-hosted Keycloak
- **MCP retry loop** on 429/502/503/504 with exponential backoff
- **MCP session DELETE** on shutdown (2025-03-26 spec compliance)
- **Richer content rendering** for image/audio/resource MCP items (no more binary base64 in the terminal)
- **Protocol-version warning** during `initialize`
- **Upstream MCP drift detection** — daily cron diffs the Inderes docs against `tests/fixtures/upstream-tools.txt`
- **Hermes + ptrclaw skill files**; `install-skill` is now host-aware (\`openclaw|hermes|ptrclaw\`)
- **C++ e2e validator for ptrclaw** against the latest main of that repo
- **Community health files**: SECURITY.md, CONTRIBUTING.md, CODEOWNERS, dependabot.yml
- **Test coverage** 12% → 73% (92 passing tests)
- **Dependency bumps**: rand 0.9, sha2 0.11, directories 6, pnpm/action-setup 6

## Test plan

- [x] \`cargo test\` — 92 pass locally
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] \`npx markdownlint-cli2@0.22.1\` — clean
- [ ] CI green on Linux/macOS/Windows (runs on PR)
- [ ] After merge: tag \`v2026.4.25\`, release workflow builds 5 target triples
- [ ] Smoke-install workflow verifies \`install.sh\` / \`install.ps1\` against the new release on all 5 platforms (fires automatically via workflow_run)