### PR TITLE
fix(install.sh): bash 3.2 empty-array expansion crashes macOS install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,8 +31,14 @@ require() {
 require curl
 require tar
 
-# Optional: authenticated downloads for private releases. Curl's -L does not
-# forward auth on redirect, so the S3-signed URL stays clean.
+# Optional: authenticated downloads for private releases or rate-limit boost.
+# Curl's -L does not forward auth on redirect, so the S3-signed URL stays clean.
+#
+# NOTE on the `${curl_auth[@]+"${curl_auth[@]}"}` expansion used below: macOS
+# ships bash 3.2 where `"${empty_array[@]}"` triggers `set -u`'s unbound-
+# variable error. The `${arr[@]+…}` form expands to nothing when the array
+# is empty, bypassing the quirk. Required for macOS runners; harmless on
+# bash 4+.
 curl_auth=()
 if [[ -n "${GH_TOKEN:-}" ]]; then
   curl_auth+=(-H "Authorization: Bearer $GH_TOKEN")
@@ -53,7 +59,7 @@ esac
 
 if [[ "$VERSION" == "latest" ]]; then
   log "Resolving latest release for $REPO"
-  VERSION="$(curl -fsSL "${curl_auth[@]}" "https://api.github.com/repos/$REPO/releases/latest" \
+  VERSION="$(curl -fsSL ${curl_auth[@]+"${curl_auth[@]}"} "https://api.github.com/repos/$REPO/releases/latest" \
     | awk -F'"' '/"tag_name":/ {print $4; exit}')"
   [[ -n "$VERSION" ]] || die "could not determine latest tag"
 fi
@@ -70,7 +76,7 @@ trap 'rm -rf "$tmp"' EXIT
 asset_accept=()
 if [[ -n "${GH_TOKEN:-}" ]]; then
   log "Resolving asset IDs for $VERSION"
-  release_meta="$(curl -fsSL "${curl_auth[@]}" \
+  release_meta="$(curl -fsSL ${curl_auth[@]+"${curl_auth[@]}"} \
     -H "Accept: application/vnd.github+json" \
     "https://api.github.com/repos/$REPO/releases/tags/$VERSION")" \
     || die "could not read release metadata for $VERSION"
@@ -104,12 +110,12 @@ else
 fi
 
 log "Downloading $archive ($VERSION)"
-curl -fsSL "${curl_auth[@]}" "${asset_accept[@]}" -o "$tmp/$archive" "$archive_url" \
+curl -fsSL ${curl_auth[@]+"${curl_auth[@]}"} ${asset_accept[@]+"${asset_accept[@]}"} -o "$tmp/$archive" "$archive_url" \
   || die "download failed: $archive_url"
 
 log "Verifying checksum"
 if [[ -n "$sums_url" ]] && \
-   curl -fsSL "${curl_auth[@]}" "${asset_accept[@]}" -o "$tmp/SHA256SUMS" "$sums_url" 2>/dev/null; then
+   curl -fsSL ${curl_auth[@]+"${curl_auth[@]}"} ${asset_accept[@]+"${asset_accept[@]}"} -o "$tmp/SHA256SUMS" "$sums_url" 2>/dev/null; then
   sum_line="$(grep -E "[[:space:]]${archive}\$" "$tmp/SHA256SUMS" || true)"
   if [[ -n "$sum_line" ]]; then
     (cd "$tmp" && printf '%s\n' "$sum_line" | shasum -a 256 -c -) \


### PR DESCRIPTION
## Summary

\`v2026.4.25\`'s post-release smoke-install run failed on \`macos-arm64\` at \"Verify binary location\". Root cause: \`\"\${empty_array[@]}\"\` is an unbound-variable error under \`set -u\` on bash 3.2 (macOS's system \`/bin/bash\`), though it's fine on bash 4+ (Linux runners).

The failing step logged:

    ./install.sh: line 107: curl_auth[@]: unbound variable
    binary missing or not executable

Fix is the idiomatic \`\${arr[@]+\"\${arr[@]}\"}\` alternate-value form, which expands to nothing when the array is empty — bypasses the quirk, harmless on newer bash. Applied to both \`curl_auth\` and \`asset_accept\` arrays.

## Test plan

- [x] Repro on local macOS: \`/bin/bash --version\` = 3.2.57, old install.sh fails as in CI.
- [x] With fix: \`INDERES_VERSION=v2026.4.25 /bin/bash install.sh\` installs the published darwin-arm64 binary, SHA-256 passes, \`inderes --version\` prints \`inderes 2026.4.25\`.
- [ ] CI matrix green (runs on PR).
- [ ] After merge: re-dispatch smoke-install against v2026.4.25 and confirm all 5 platforms pass.

## Note

The \`v2026.4.25\` release itself is fine — binaries + SHA256SUMS are correctly published. Only the install.sh shipped via \`raw.githubusercontent.com/main/install.sh\` needed the fix. Once this lands on main, every user fetching install.sh gets the fixed version immediately; no new tag required.