### PR TITLE
ci(smoke): drop macos-x64 (macos-13) from smoke-install matrix

### DIFF
--- a/.github/workflows/smoke-install.yml
+++ b/.github/workflows/smoke-install.yml
@@ -38,11 +38,17 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
+      # macos-x64 (macos-13, Intel) is deliberately absent: install.sh is
+      # arch-agnostic past `uname -m`, so macos-arm64 catches every Darwin-
+      # specific shell quirk we'd notice here (including the bash 3.2 empty-
+      # array issue). Dropping it avoids the long queue on GitHub's scarcer
+      # Intel runner class. release.yml still builds x86_64-apple-darwin
+      # binaries, so Intel Mac users continue to get a prebuilt release
+      # tarball — it's just not CI-smoke-tested.
       matrix:
         include:
           - { os: ubuntu-latest,    target: linux-x64 }
           - { os: ubuntu-24.04-arm, target: linux-arm64 }
-          - { os: macos-13,         target: macos-x64 }
           - { os: macos-latest,     target: macos-arm64 }
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary

Removes the Intel Mac smoke-install job. The \`macos-13\` runner class on GitHub Actions is scarcer than \`macos-latest\` (Apple Silicon) and frequently queues long enough (minutes to hours) that the workflow stalls. The v2026.4.25 smoke run ended up stuck on this slot for exactly that reason.

## Why this is safe

- \`install.sh\` is architecture-agnostic past its \`uname -m\` lookup. Every Darwin-specific shell quirk that matters (e.g. the bash 3.2 empty-array issue fixed in #7) fires identically on arm64.
- \`release.yml\` still builds \`x86_64-apple-darwin\` binaries, so Intel Mac users continue to get a prebuilt release tarball. Only the post-release install-script verification is skipped for that arch.

## Remaining smoke matrix

| Slot | Runner | Class |
|---|---|---|
| linux-x64 | \`ubuntu-latest\` | plentiful |
| linux-arm64 | \`ubuntu-24.04-arm\` | plentiful |
| macos-arm64 | \`macos-latest\` | plentiful |
| windows-x64 (install.ps1) | \`windows-latest\` | plentiful |

Four runners total. No scarce classes remaining.

## Test plan

- [ ] CI green on PR (runs the standard matrix, not smoke-install)
- [ ] After merge: re-dispatch smoke-install against \`v2026.4.25\` — expect 3 install.sh + 1 install.ps1 = 4 jobs, all green with the bash fix from #7 applied.