### PR TITLE
fix(install.sh): pipefail kills 'latest' resolve when awk closes pipe early (closes #9)

### DIFF
--- a/.github/workflows/smoke-install.yml
+++ b/.github/workflows/smoke-install.yml
@@ -177,3 +177,29 @@ jobs:
             }
             Get-Content $out -TotalCount 3
           }
+
+  install-sh-latest:
+    # Regression coverage for github.com/heikki-laitala/inderes-cli/issues/9.
+    # The matrix above always passes an explicit INDERES_VERSION, which means
+    # install.sh's `latest` resolution branch (curl -> awk pipeline) was
+    # never exercised in CI. This dedicated job runs install.sh with no
+    # version pinned so the API + parse path runs under `set -euo pipefail`
+    # exactly as a real user invoking `curl … | bash` does.
+    name: install.sh (latest-tag resolution)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run install.sh with no version pinned (defaults to "latest")
+        env:
+          INDERES_INSTALL_DIR: ${{ github.workspace }}/bin
+          # INDERES_VERSION deliberately unset — exercise the latest branch.
+        run: ./install.sh
+
+      - name: Verify --version
+        run: |
+          out="$("${{ github.workspace }}/bin/inderes" --version)"
+          echo "$out"
+          echo "$out" | grep -q '^inderes ' \
+            || { echo "unexpected version output"; exit 1; }

--- a/install.sh
+++ b/install.sh
@@ -59,8 +59,15 @@ esac
 
 if [[ "$VERSION" == "latest" ]]; then
   log "Resolving latest release for $REPO"
-  VERSION="$(curl -fsSL ${curl_auth[@]+"${curl_auth[@]}"} "https://api.github.com/repos/$REPO/releases/latest" \
-    | awk -F'"' '/"tag_name":/ {print $4; exit}')"
+  # Fetch first, parse second. Piping curl into `awk '... {exit}'` closes
+  # the pipe before curl finishes writing the body, which under
+  # `set -o pipefail` propagates curl's SIGPIPE (exit 23) and aborts the
+  # whole installer — even though the tag was extracted successfully.
+  # See https://github.com/heikki-laitala/inderes-cli/issues/9.
+  release_json="$(curl -fsSL ${curl_auth[@]+"${curl_auth[@]}"} \
+    "https://api.github.com/repos/$REPO/releases/latest")" \
+    || die "could not query latest release"
+  VERSION="$(printf '%s\n' "$release_json" | awk -F'"' '/"tag_name":/ {print $4; exit}')"
   [[ -n "$VERSION" ]] || die "could not determine latest tag"
 fi
 


### PR DESCRIPTION
Closes #9.

## Summary

Reported by @henry-wilkins: invoking \`install.sh\` on Linux with \`set -euo pipefail\` aborts with \`exit 23\` even though the tag was extracted correctly. The diagnosis in the issue is exactly right.

## Root cause

\`\`\`bash
VERSION=\"\$(curl ... \"https://api.github.com/repos/.../releases/latest\" | awk -F'\"' '/\"tag_name\":/ {print \$4; exit}')\"
\`\`\`

- \`awk\` reads enough of the API response to find \`tag_name\` and exits.
- \`curl\` is still mid-write to the pipe; SIGPIPE/EPIPE kicks in.
- \`curl\` exits with code 23 (\"Failure writing output to destination\").
- \`pipefail\` propagates that non-zero status to the script — even though the value was already captured.

## Fix

Capture the body once, then parse — no back-pressure window. Patch is the reporter's suggestion verbatim.

\`\`\`bash
release_json=\"\$(curl ... \"...releases/latest\")\"
VERSION=\"\$(printf '%s\\n' \"\$release_json\" | awk ... {exit}')\"
\`\`\`

## Why the smoke tests didn't catch it

Existing smoke-install matrix always passes a specific \`INDERES_VERSION=v...\` from either dispatch input or \`workflow_run\` lookup — meaning the \`latest\` resolution branch was never executed in CI.

Added a dedicated \`install-sh-latest\` job that runs install.sh with no version pinned, under the same \`set -euo pipefail\` shell flags. This would have caught the bug pre-release.

## Test plan

- [x] Reproduced locally (verified \`set -euo pipefail\` plus old install.sh dies on the curl|awk pipe)
- [x] \`bash -n install.sh\` clean
- [x] Local fix end-to-end: \`INDERES_VERSION=latest bash -e -u -o pipefail install.sh\` exits 0 and produces a working binary
- [ ] CI green on PR
- [ ] After merge, re-dispatch smoke-install — new \`install-sh-latest\` job exercises the fixed path against v2026.4.25