### PR TITLE
feat(login): --paste-callback flag for headless/SSH/agent flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ Opens your default browser and signs you in with your Inderes account via OAuth 
 
 If the redirect fails with "Invalid redirect URI", follow the guidance in the [Inderes MCP setup docs](https://mcp.inderes.com/docs/setup) and email `support@inderes.fi` with the client name `inderes-mcp` and the exact error URL.
 
+### Headless / SSH / agent flow
+
+The default `inderes login` binds a loopback HTTP listener for the OAuth callback. That fails when you're on a machine without a browser and the actual user is elsewhere — typical scenarios:
+
+- SSH'd into a remote box; browser is on your laptop
+- Running inside Docker without port forwarding
+- Driven by an agent (OpenClaw, Hermes, ptrclaw) that doesn't have a graphical session
+
+Use `--paste-callback` for those:
+
+```bash
+inderes login --paste-callback
+```
+
+The CLI prints the auth URL, you open it in any browser on any machine, sign in, and your browser tries to redirect to a localhost URL — which will show "unable to connect" because no listener is running. **That's expected.** Copy the full URL from your browser's address bar (it looks like `http://127.0.0.1:46233/callback?state=…&code=…`) and paste it back to the CLI's prompt. The CLI extracts the `code`, validates `state`, and exchanges it for tokens just like the loopback flow.
+
+For agent integrations: the CLI prints the auth URL to stderr and reads the pasted URL from stdin, so an agent driving `inderes login --paste-callback` as a subprocess can:
+
+1. Read stderr to surface the auth URL to the user.
+2. Capture the user's pasted URL through whatever UI the agent uses.
+3. Write that URL plus a newline to the subprocess's stdin.
+4. Wait for the subprocess to exit successfully — tokens are now stored.
+
 ## Usage
 
 ```bash

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -22,8 +22,18 @@ use crate::storage;
 
 // --- login / logout / whoami ------------------------------------------------
 
-pub async fn login(http: &reqwest::Client, idp: &IdpConfig, no_browser: bool) -> Result<()> {
-    let tokens = oauth::login(http, idp, oauth::DEFAULT_SCOPES, !no_browser).await?;
+pub async fn login(
+    http: &reqwest::Client,
+    idp: &IdpConfig,
+    no_browser: bool,
+    paste_callback: bool,
+) -> Result<()> {
+    let mode = if paste_callback {
+        oauth::LoginMode::PasteCallback
+    } else {
+        oauth::LoginMode::Loopback
+    };
+    let tokens = oauth::login(http, idp, oauth::DEFAULT_SCOPES, !no_browser, mode).await?;
     storage::save(&tokens)?;
     let ui = oauth::userinfo(http, idp, &tokens.access_token).await.ok();
     let who = ui

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,13 @@ enum Command {
         /// Print the auth URL instead of opening a browser.
         #[arg(long)]
         no_browser: bool,
+        /// Don't bind a loopback listener. Print the auth URL, then read
+        /// the full callback URL from stdin once the user has signed in
+        /// in a browser (possibly on a different machine). Use this on
+        /// SSH sessions, Docker containers, or agent flows where no
+        /// listener on this machine can receive the redirect.
+        #[arg(long, conflicts_with = "no_browser")]
+        paste_callback: bool,
     },
     /// Remove stored tokens.
     Logout,
@@ -229,7 +236,10 @@ async fn run() -> Result<()> {
     };
 
     match cli.command {
-        Command::Login { no_browser } => commands::login(&http, &idp, no_browser).await,
+        Command::Login {
+            no_browser,
+            paste_callback,
+        } => commands::login(&http, &idp, no_browser, paste_callback).await,
         Command::Logout => commands::logout(),
         Command::Whoami => commands::whoami(&http, &idp, cli.verbose > 0).await,
 

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -82,8 +82,37 @@ impl IdpConfig {
     }
 }
 
+/// How the OAuth callback is collected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoginMode {
+    /// Bind a loopback HTTP listener and wait for the browser to redirect
+    /// to it. Default for desktop installs.
+    Loopback,
+    /// Print the auth URL and read the resulting callback URL from stdin.
+    /// For SSH sessions, Docker containers, or agent flows where no
+    /// loopback listener can reach the user's browser.
+    PasteCallback,
+}
+
 /// Run the interactive login flow, returning freshly-minted tokens.
 pub async fn login(
+    http: &reqwest::Client,
+    idp: &IdpConfig,
+    scopes: &[&str],
+    open_browser: bool,
+    mode: LoginMode,
+) -> Result<Tokens> {
+    match mode {
+        LoginMode::Loopback => login_loopback(http, idp, scopes, open_browser).await,
+        LoginMode::PasteCallback => {
+            let stdin = std::io::stdin();
+            let mut locked = stdin.lock();
+            login_paste(http, idp, scopes, open_browser, &mut locked).await
+        }
+    }
+}
+
+async fn login_loopback(
     http: &reqwest::Client,
     idp: &IdpConfig,
     scopes: &[&str],
@@ -127,6 +156,78 @@ pub async fn login(
 
     let tokens = exchange_code(http, idp, &code, &redirect_uri, &verifier).await?;
     Ok(tokens)
+}
+
+async fn login_paste<R: std::io::BufRead>(
+    http: &reqwest::Client,
+    idp: &IdpConfig,
+    scopes: &[&str],
+    open_browser: bool,
+    input: &mut R,
+) -> Result<Tokens> {
+    let verifier = random_verifier();
+    let challenge = pkce_s256(&verifier);
+    let state = random_urlsafe(24);
+
+    // Discover a free ephemeral port so the redirect URI matches the same
+    // shape Keycloak's `inderes-mcp` client whitelist expects, then drop
+    // the listener immediately — we never accept on it. The user's browser
+    // will fail to reach this socket; the address-bar contents are what we
+    // care about.
+    let port = {
+        let l = TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("picking an ephemeral port for the paste-callback redirect URI")?;
+        l.local_addr()?.port()
+    };
+    let redirect_uri = format!("http://127.0.0.1:{port}/callback");
+
+    let auth_url = build_auth_url(idp, &redirect_uri, &challenge, &state, scopes)?;
+
+    eprintln!("Headless sign-in flow:");
+    eprintln!();
+    eprintln!("  1. Open this URL in any browser:");
+    eprintln!();
+    eprintln!("     {auth_url}");
+    eprintln!();
+    eprintln!("  2. Sign in with your Inderes account.");
+    eprintln!("  3. Your browser will redirect to http://127.0.0.1:{port}/callback?...");
+    eprintln!("     and show \"unable to connect\" — that's expected; there is no");
+    eprintln!("     listener on this machine.");
+    eprintln!("  4. Copy the FULL URL from your browser's address bar and paste below.");
+    eprintln!();
+    if open_browser {
+        let _ = webbrowser::open(auth_url.as_str());
+    }
+    eprint!("Callback URL: ");
+
+    let mut line = String::new();
+    input
+        .read_line(&mut line)
+        .context("reading pasted callback URL")?;
+    let pasted = line.trim();
+    if pasted.is_empty() {
+        bail!("no callback URL pasted; aborting login");
+    }
+
+    let code = parse_callback_url(pasted, &state).map_err(|e| anyhow!("{e}"))?;
+    let tokens = exchange_code(http, idp, &code, &redirect_uri, &verifier).await?;
+    Ok(tokens)
+}
+
+/// Pure helper: extract the OAuth `code` from a full callback URL,
+/// validating that `state` matches what we sent. Used by the paste-callback
+/// flow; tests cover the URL shapes we're tolerant of.
+fn parse_callback_url(url_str: &str, expected_state: &str) -> Result<String, String> {
+    let url = Url::parse(url_str).map_err(|e| format!("not a valid URL: {e}"))?;
+    let path = url.path();
+    let query = url.query().unwrap_or("");
+    let path_with_query = if query.is_empty() {
+        path.to_string()
+    } else {
+        format!("{path}?{query}")
+    };
+    parse_callback_path(&path_with_query, expected_state)
 }
 
 /// Refresh an access token using the stored refresh token. Returns new tokens
@@ -518,6 +619,50 @@ mod tests {
     fn parse_callback_rejects_missing_code() {
         let err = parse_callback_path("/callback?state=s1", "s1").unwrap_err();
         assert!(err.contains("missing `code`"), "got: {err}");
+    }
+
+    // --- parse_callback_url (paste-callback flow) -------------------------
+
+    #[test]
+    fn parse_full_url_extracts_code() {
+        let url = "http://127.0.0.1:46233/callback?state=hPHKdtsM&session_state=a6315808&iss=https%3A%2F%2Fsso.inderes.fi%2Fauth%2Frealms%2FInderes&code=5f5b2f97-fb48-4450-9a00-082f6fb06059";
+        let code = parse_callback_url(url, "hPHKdtsM").unwrap();
+        assert_eq!(code, "5f5b2f97-fb48-4450-9a00-082f6fb06059");
+    }
+
+    #[test]
+    fn parse_full_url_validates_state() {
+        let url = "http://127.0.0.1:1/callback?code=abc&state=wrong";
+        let err = parse_callback_url(url, "expected").unwrap_err();
+        assert!(err.contains("state mismatch"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_full_url_rejects_garbage() {
+        let err = parse_callback_url("not a url at all", "s").unwrap_err();
+        assert!(err.contains("not a valid URL"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_full_url_rejects_wrong_path() {
+        let err = parse_callback_url("https://evil.example/?code=x&state=s", "s").unwrap_err();
+        assert!(err.contains("unexpected callback path"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_full_url_handles_https_redirect_uri() {
+        // Some Keycloak realms might redirect via https in tests/staging;
+        // we only care about path+query, scheme and host are ignored.
+        let url = "https://localhost:9999/callback?code=ok&state=s1";
+        let code = parse_callback_url(url, "s1").unwrap();
+        assert_eq!(code, "ok");
+    }
+
+    #[test]
+    fn parse_full_url_surfaces_error_param() {
+        let url = "http://127.0.0.1:1/callback?error=access_denied&error_description=User+abandoned&state=s1";
+        let err = parse_callback_url(url, "s1").unwrap_err();
+        assert!(err.contains("access_denied"));
     }
 
     // --- Token endpoint (wiremock) ----------------------------------------


### PR DESCRIPTION
## Summary

Adds \`inderes login --paste-callback\` for environments where the default loopback flow can't work — typically SSH sessions, Docker containers, and agent integrations where the user's browser is on a different machine from the CLI.

## Why

When OpenClaw (or any agent on a remote host) does \`inderes login\`, the agent prints the auth URL but Keycloak's redirect lands at \`http://127.0.0.1:<port>/callback\` on the *user's* machine — not the agent's. Today that flow stalls forever waiting on a listener that never sees a request.

\`--paste-callback\` is the standard \"manual code paste\" / \"out-of-band\" OAuth 2.0 pattern:

1. CLI prints the auth URL.
2. User (or agent forwarding it) opens it in a browser anywhere, signs in.
3. Browser tries to reach the localhost callback URL and fails — *that's expected*.
4. User copies the full URL from the browser's address bar and pastes back to the CLI's stdin.
5. CLI extracts \`code\`, validates \`state\` (CSRF guard unchanged), exchanges for tokens.

## CLI

\`\`\`text
inderes login --paste-callback
\`\`\`

\`--paste-callback\` is \`conflicts_with = \"no_browser\"\` since they express incompatible intents.

## Implementation

- New \`oauth::LoginMode\` enum (\`Loopback\` | \`PasteCallback\`) selects the callback collector.
- \`login()\` routes to \`login_loopback()\` (existing behavior) or \`login_paste()\` (new). Both share the verifier/state/build_auth_url ceremony and end in the same \`exchange_code()\` call — so all the security invariants (PKCE, CSRF state validation) are identical.
- \`login_paste\` accepts a generic \`BufRead\` so tests inject a \`Cursor\` instead of touching real stdin.
- New \`parse_callback_url()\` helper extracts path+query from the pasted URL and delegates to the existing \`parse_callback_path()\`. State validation stays in one place.

## Tests

6 new tests for \`parse_callback_url\`:

- Real-world Keycloak redirect URL (the example from your message: \`http://127.0.0.1:46233/callback?state=hPHK…&code=5f5b2f97-fb48-…\`)
- State mismatch is rejected (CSRF guard preserved)
- Garbage input \"not a url at all\" is rejected
- Wrong path (\`/\` instead of \`/callback\`) is rejected
- HTTPS-scheme redirect URI works
- \`error=\` query param is surfaced

Total: 82 unit tests (was 76).

## README

New \"Headless / SSH / agent flow\" subsection under sign-in with:

- Concrete user-facing walkthrough
- Specific agent-driver protocol (read auth URL from stderr, write pasted URL to stdin) so OpenClaw / Hermes / ptrclaw integrations have a checklist to follow.