### PR TITLE
release: v2026.4.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "inderes-cli"
-version = "2026.4.25"
+version = "2026.4.26"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inderes-cli"
-version = "2026.4.25"
+version = "2026.4.26"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Heikki Laitala"]


### PR DESCRIPTION
Same-day calendar bump. Rolls up paste-callback flag (#11), pipefail/awk fix (closes #9, PR #10), bash 3.2 empty-array fix (#7), macos-x64 smoke drop (#8), and install-sh-latest regression test job. 98 tests pass.