### PR TITLE
release: v2026.4.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "inderes-cli"
-version = "2026.4.26"
+version = "2026.4.27"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inderes-cli"
-version = "2026.4.26"
+version = "2026.4.27"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Heikki Laitala"]


### PR DESCRIPTION
Same-day calendar bump. Rolls up:

- feat: `inderes upgrade` + `inderes uninstall` (#13)
- fix(upgrade): pipefail / ErrorActionPreference so download failures surface (Codex review on #13)
- test(cli): gate uninstall-removes-skills test off Windows

98 → 112 tests. No breaking surface changes.