### PR TITLE
feat(forum): read-only forum subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,17 @@ Write tests first. Red → Green → Refactor. New features and bug fixes start 
 
 Never log secrets or tokens. Validate at system boundaries. Keep network/filesystem/shell scope narrow.
 
+## Process rules
+
+1. **Think before coding** — State assumptions. Ask if uncertain. Present alternatives when ambiguous. Stop when confused.
+2. **Simplicity first** — Minimum code that solves the problem. No abstractions for single-use code. No features beyond what was asked.
+3. **Surgical changes** — Touch only what you must. Don't "improve" adjacent code, comments, or formatting.
+4. **Goal-driven, not step-driven** — Define success criteria, iterate until verified.
+5. **Use the model only for judgment calls** — Classification, drafting, summarization, extraction. Not for routing, retries, or deterministic transforms. If code can answer, code answers.
+6. **Surface conflicts, don't average them** — If two patterns contradict, pick one (more recent / more tested), explain why, flag the other.
+7. **Tests verify intent** — Tests must encode *why* behavior matters, not just *what* it does. A test that can't fail when business logic changes is wrong.
+8. **Checkpoint after every significant step** — Summarize what's done, verified, and left. Don't continue from a state you can't describe back.
+
 ## Before Committing
 
 Always run lint and tests before creating commits or PRs:
@@ -49,3 +60,4 @@ npx -y markdownlint-cli2@0.22.1        # markdown lint (uses .markdownlint-cli2.
 - **Git**: Conventional commits (`feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `ci:`, `docs:`). No `Co-Authored-By` trailer. No "Generated with Claude Code" footer in PR descriptions.
 - **Releases**: Calendar-versioned. Bump `Cargo.toml` `version = "YYYY.M.D"`, commit, then `git tag vYYYY.M.D && git push origin vYYYY.M.D` — the release workflow builds binaries for the five target triples and uploads `SHA256SUMS`.
 - **Repo layout**: `src/main.rs` (clap dispatch) → `src/commands.rs` (subcommand bodies) → `src/mcp.rs` (Streamable-HTTP JSON-RPC) ← `src/auth.rs` ← `src/oauth.rs` + `src/storage.rs`. The skill text lives at `src/skill/SKILL.md` and is embedded into the binary via `include_str!`.
+- **Code review**: Before opening a PR, run the local reviewer — `codex review --base main --title "<pr title>"` from the repo root — and fix its findings first. Then open the PR and post a comment `@codex review` to trigger the GitHub automated review (Codex does not review unless asked). When that review arrives, fix every finding and reply to the reviewer explaining each fix. Once the fixes are pushed and CI is green, merge the PR automatically — no further confirmation needed.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,28 @@ Every tool-calling subcommand accepts `--json` to emit raw MCP output:
 inderes --json search "Nokia" | jq '.content[0].text'
 ```
 
+### Forum (public, no login)
+
+`inderes forum` reads the public [Inderes forum](https://forum.inderes.com) (a Discourse instance) directly over its JSON API. This path is **independent of the MCP server and Keycloak** — it sends no credentials and reads only public content, so it works before (and without) `inderes login`.
+
+```bash
+inderes forum search "Nokia"   # full-text search across topics and posts
+inderes forum topic 74         # a topic's posts (page 1)
+inderes forum topic 74 --page 2  # next page (~20 posts) of a long thread
+inderes forum latest           # latest active topics
+inderes forum categories       # category list
+```
+
+`--json` emits the raw Discourse fields (`cooked`, `username`, `created_at`, …), handy for scripting or downstream analysis:
+
+```bash
+inderes --json forum topic 74 | jq '.post_stream.posts[].cooked'
+```
+
+> **Why no login.** The forum is open to all, so authentication isn't required — and isn't currently possible anyway: the forum signs in via the same Keycloak but issues a Discourse session cookie rather than a reusable token, and its third-party User-API-Key feature is disabled. If the forum is ever switched to login-required, anonymous reads return 401/403 and the CLI reports that explicitly instead of failing cryptically. Point the forum base elsewhere with `INDERES_FORUM_URL`.
+>
+> **Note.** `forum topic <id>` returns ~20 posts per page; pass `--page N` (1-based) to walk a longer thread. There is no auto-fetch-all flag yet — bulk corpus retrieval is planned alongside a local cache.
+
 ## Upgrade
 
 ```bash
@@ -171,6 +193,7 @@ inderes completions powershell | Out-String | Invoke-Expression
 | Variable / flag | Purpose | Default |
 |---|---|---|
 | `--endpoint` / `INDERES_MCP_ENDPOINT` | Override the MCP HTTP endpoint | `https://mcp.inderes.com/` |
+| `INDERES_FORUM_URL` | Override the forum base URL used by `inderes forum` | `https://forum.inderes.com` |
 | `--json` | Emit raw JSON from MCP tool calls | off |
 | `-v` / `-vv` | Increase logging verbosity (`warn` → `info` → `debug`) | `warn` |
 | `INDERES_LOG` | `tracing` env filter (overrides `-v`) | unset |
@@ -200,6 +223,7 @@ Written atomically (tempfile + rename) so a crash can't leave a half-written fil
 - `src/storage.rs` — atomic-rename JSON file at the platform config dir (0600 on Unix).
 - `src/mcp.rs` — MCP 2025-03-26 Streamable HTTP client, handles both `application/json` and `text/event-stream` responses.
 - `src/commands.rs` — subcommand implementations and output formatting.
+- `src/forum.rs` — read-only Discourse JSON client for the public forum (no auth, independent of MCP).
 - `src/skill/{openclaw,hermes,ptrclaw}.md` — embedded at compile time; `inderes install-skill <host>` writes the right one to disk.
 
 ## Development

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -15,6 +15,7 @@ use clap_complete::Shell;
 use serde_json::{json, Map, Value};
 
 use crate::auth;
+use crate::forum;
 use crate::mcp::McpClient;
 use crate::oauth::{self, IdpConfig};
 use crate::skill;
@@ -232,6 +233,43 @@ pub async fn documents_read(
         }),
     )
     .await
+}
+
+// --- forum (public Discourse, no auth) -------------------------------------
+
+pub async fn forum_search(ctx: &ToolCtx<'_>, query: &str) -> Result<()> {
+    let client = forum::ForumClient::new(ctx.http, &forum::forum_base());
+    let v = client.search(query).await?;
+    print_forum(&v, ctx.json_output, forum::render_search)
+}
+
+pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str) -> Result<()> {
+    let client = forum::ForumClient::new(ctx.http, &forum::forum_base());
+    let v = client.topic(id).await?;
+    print_forum(&v, ctx.json_output, forum::render_topic)
+}
+
+pub async fn forum_latest(ctx: &ToolCtx<'_>) -> Result<()> {
+    let client = forum::ForumClient::new(ctx.http, &forum::forum_base());
+    let v = client.latest().await?;
+    print_forum(&v, ctx.json_output, forum::render_latest)
+}
+
+pub async fn forum_categories(ctx: &ToolCtx<'_>) -> Result<()> {
+    let client = forum::ForumClient::new(ctx.http, &forum::forum_base());
+    let v = client.categories().await?;
+    print_forum(&v, ctx.json_output, forum::render_categories)
+}
+
+/// Print a forum response: raw pretty JSON under `--json`, otherwise the
+/// supplied human renderer.
+fn print_forum(v: &Value, as_json: bool, render: fn(&Value) -> String) -> Result<()> {
+    if as_json {
+        println!("{}", serde_json::to_string_pretty(v)?);
+    } else {
+        print!("{}", render(v));
+    }
+    Ok(())
 }
 
 // --- generic escape hatch --------------------------------------------------

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -237,27 +237,27 @@ pub async fn documents_read(
 
 // --- forum (public Discourse, no auth) -------------------------------------
 
+fn forum_client<'a>(ctx: &ToolCtx<'a>) -> forum::ForumClient<'a> {
+    forum::ForumClient::new(ctx.http, &forum::forum_base())
+}
+
 pub async fn forum_search(ctx: &ToolCtx<'_>, query: &str) -> Result<()> {
-    let client = forum::ForumClient::new(ctx.http, &forum::forum_base());
-    let v = client.search(query).await?;
+    let v = forum_client(ctx).search(query).await?;
     print_forum(&v, ctx.json_output, forum::render_search)
 }
 
 pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str, page: u32) -> Result<()> {
-    let client = forum::ForumClient::new(ctx.http, &forum::forum_base());
-    let v = client.topic(id, page).await?;
+    let v = forum_client(ctx).topic(id, page).await?;
     print_forum(&v, ctx.json_output, forum::render_topic)
 }
 
 pub async fn forum_latest(ctx: &ToolCtx<'_>) -> Result<()> {
-    let client = forum::ForumClient::new(ctx.http, &forum::forum_base());
-    let v = client.latest().await?;
+    let v = forum_client(ctx).latest().await?;
     print_forum(&v, ctx.json_output, forum::render_latest)
 }
 
 pub async fn forum_categories(ctx: &ToolCtx<'_>) -> Result<()> {
-    let client = forum::ForumClient::new(ctx.http, &forum::forum_base());
-    let v = client.categories().await?;
+    let v = forum_client(ctx).categories().await?;
     print_forum(&v, ctx.json_output, forum::render_categories)
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -243,9 +243,9 @@ pub async fn forum_search(ctx: &ToolCtx<'_>, query: &str) -> Result<()> {
     print_forum(&v, ctx.json_output, forum::render_search)
 }
 
-pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str) -> Result<()> {
+pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str, page: u32) -> Result<()> {
     let client = forum::ForumClient::new(ctx.http, &forum::forum_base());
-    let v = client.topic(id).await?;
+    let v = client.topic(id, page).await?;
     print_forum(&v, ctx.json_output, forum::render_topic)
 }
 

--- a/src/forum.rs
+++ b/src/forum.rs
@@ -1,0 +1,450 @@
+//! Read-only client for the public Discourse JSON API at `forum.inderes.com`.
+//!
+//! Discourse serves public content as JSON whenever you append `.json` to a
+//! page URL — no authentication required. This is deliberately **separate**
+//! from the MCP/OAuth path: the Keycloak tokens minted for the `inderes-mcp`
+//! client are not valid forum credentials, and Discourse runs its own session
+//! model. We only ever read; we never send credentials here.
+//!
+//! Human output is best-effort (HTML stripped from post bodies). Agents doing
+//! downstream work — e.g. sentiment analysis over posts — should use `--json`
+//! to get the raw Discourse fields (`cooked`, `created_at`, `username`, …).
+
+use anyhow::{bail, Context, Result};
+use serde_json::Value;
+
+/// Public Discourse instance. Overridable via `INDERES_FORUM_URL` (used by
+/// tests to point at a mock server; also lets a self-hosted mirror be swapped
+/// in without a recompile).
+pub const DEFAULT_FORUM_URL: &str = "https://forum.inderes.com";
+
+/// Resolve the forum base URL from the environment, falling back to the
+/// public Inderes forum.
+pub fn forum_base() -> String {
+    std::env::var("INDERES_FORUM_URL").unwrap_or_else(|_| DEFAULT_FORUM_URL.to_string())
+}
+
+/// Minimal read-only HTTP client over the Discourse JSON API.
+pub struct ForumClient<'a> {
+    http: &'a reqwest::Client,
+    base: String,
+}
+
+impl<'a> ForumClient<'a> {
+    pub fn new(http: &'a reqwest::Client, base: &str) -> Self {
+        Self {
+            http,
+            // Normalize so `format!("{base}{path}")` never doubles a slash.
+            base: base.trim_end_matches('/').to_string(),
+        }
+    }
+
+    async fn get_json(&self, path: &str, query: &[(&str, &str)]) -> Result<Value> {
+        let url = format!("{}{}", self.base, path);
+        let resp = self
+            .http
+            .get(&url)
+            .query(query)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .with_context(|| format!("GET {url}"))?;
+        let status = resp.status();
+        // Body is intentionally kept out of the error: Discourse error pages
+        // can be large HTML, and we never want to splatter that at the user.
+        if !status.is_success() {
+            bail!("forum request to {path} returned HTTP {status}");
+        }
+        let body = resp.text().await.unwrap_or_default();
+        serde_json::from_str(&body)
+            .with_context(|| format!("parsing forum JSON response from {path}"))
+    }
+
+    /// Full-text search across topics and posts (`/search.json?q=`).
+    pub async fn search(&self, query: &str) -> Result<Value> {
+        self.get_json("/search.json", &[("q", query)]).await
+    }
+
+    /// A single topic with its post stream (`/t/<id>.json`).
+    pub async fn topic(&self, id: &str) -> Result<Value> {
+        let path = format!("/t/{id}.json");
+        self.get_json(&path, &[]).await
+    }
+
+    /// Latest active topics (`/latest.json`).
+    pub async fn latest(&self) -> Result<Value> {
+        self.get_json("/latest.json", &[]).await
+    }
+
+    /// Forum categories (`/categories.json`).
+    pub async fn categories(&self) -> Result<Value> {
+        self.get_json("/categories.json", &[]).await
+    }
+}
+
+// --- human-readable rendering ----------------------------------------------
+//
+// Each renderer returns a String so it can be unit-tested without touching
+// stdout. The `--json` path bypasses all of these and prints the raw value.
+
+/// Search results: one line per matched topic, with a stripped blurb from the
+/// best-matching post when Discourse supplies one.
+pub fn render_search(v: &Value) -> String {
+    let topics = v.get("topics").and_then(Value::as_array);
+    let posts = v.get("posts").and_then(Value::as_array);
+    let Some(topics) = topics.filter(|t| !t.is_empty()) else {
+        return "No matching topics.\n".to_string();
+    };
+    let mut out = String::new();
+    for t in topics {
+        let id = t.get("id").and_then(Value::as_i64).unwrap_or(0);
+        let title = t
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("(untitled)");
+        let count = t.get("posts_count").and_then(Value::as_i64).unwrap_or(0);
+        out.push_str(&format!("#{id}  {title}  ({count} posts)\n"));
+        if let Some(blurb) = posts.and_then(|ps| blurb_for_topic(ps, id)) {
+            out.push_str(&format!("    {}\n", truncate(&strip_html(&blurb), 200)));
+        }
+    }
+    out.push_str("\nOpen a topic with: inderes forum topic <id>\n");
+    out
+}
+
+/// A topic: title followed by every post in the stream, full text (HTML
+/// stripped). Full bodies — not truncated — because the post text is the
+/// payload for downstream analysis.
+pub fn render_topic(v: &Value) -> String {
+    let title = v
+        .get("title")
+        .and_then(Value::as_str)
+        .unwrap_or("(untitled)");
+    let mut out = format!("{title}\n");
+    if let Some(id) = v.get("id").and_then(Value::as_i64) {
+        out.push_str(&format!("topic #{id}\n"));
+    }
+    out.push('\n');
+
+    let posts = v
+        .get("post_stream")
+        .and_then(|s| s.get("posts"))
+        .and_then(Value::as_array);
+    let Some(posts) = posts.filter(|p| !p.is_empty()) else {
+        out.push_str("(no posts)\n");
+        return out;
+    };
+    for p in posts {
+        let n = p.get("post_number").and_then(Value::as_i64).unwrap_or(0);
+        let who = p.get("username").and_then(Value::as_str).unwrap_or("?");
+        let when = p.get("created_at").and_then(Value::as_str).unwrap_or("");
+        out.push_str(&format!("#{n} @{who} ({when}):\n"));
+        let body = p.get("cooked").and_then(Value::as_str).unwrap_or("");
+        out.push_str(&strip_html(body));
+        out.push_str("\n\n");
+    }
+    out
+}
+
+/// Latest topics list (`topic_list.topics`).
+pub fn render_latest(v: &Value) -> String {
+    let topics = v
+        .get("topic_list")
+        .and_then(|l| l.get("topics"))
+        .and_then(Value::as_array);
+    let Some(topics) = topics.filter(|t| !t.is_empty()) else {
+        return "No topics.\n".to_string();
+    };
+    let mut out = String::new();
+    for t in topics {
+        let id = t.get("id").and_then(Value::as_i64).unwrap_or(0);
+        let title = t
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("(untitled)");
+        let count = t.get("posts_count").and_then(Value::as_i64).unwrap_or(0);
+        let views = t.get("views").and_then(Value::as_i64).unwrap_or(0);
+        out.push_str(&format!("#{id}  {title}  ({count} posts, {views} views)\n"));
+    }
+    out.push_str("\nOpen a topic with: inderes forum topic <id>\n");
+    out
+}
+
+/// Categories list (`category_list.categories`).
+pub fn render_categories(v: &Value) -> String {
+    let cats = v
+        .get("category_list")
+        .and_then(|l| l.get("categories"))
+        .and_then(Value::as_array);
+    let Some(cats) = cats.filter(|c| !c.is_empty()) else {
+        return "No categories.\n".to_string();
+    };
+    let mut out = String::new();
+    for c in cats {
+        let name = c.get("name").and_then(Value::as_str).unwrap_or("(unnamed)");
+        let slug = c.get("slug").and_then(Value::as_str).unwrap_or("");
+        let count = c.get("topic_count").and_then(Value::as_i64).unwrap_or(0);
+        out.push_str(&format!("{name}  [{slug}]  ({count} topics)\n"));
+        if let Some(desc) = c.get("description_text").and_then(Value::as_str) {
+            if !desc.is_empty() {
+                out.push_str(&format!("    {}\n", truncate(desc, 160)));
+            }
+        }
+    }
+    out
+}
+
+// --- pure helpers ----------------------------------------------------------
+
+/// Find the `blurb` of the first search post belonging to `topic_id`.
+fn blurb_for_topic(posts: &[Value], topic_id: i64) -> Option<String> {
+    posts.iter().find_map(|p| {
+        let same = p.get("topic_id").and_then(Value::as_i64) == Some(topic_id);
+        if same {
+            p.get("blurb")
+                .and_then(Value::as_str)
+                .filter(|b| !b.is_empty())
+                .map(str::to_string)
+        } else {
+            None
+        }
+    })
+}
+
+/// Best-effort HTML → text: drop tags, collapse whitespace, decode the handful
+/// of entities Discourse emits. Not a parser; good enough for terminal reading.
+fn strip_html(s: &str) -> String {
+    let mut text = String::with_capacity(s.len());
+    let mut in_tag = false;
+    for c in s.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if in_tag => {}
+            _ => text.push(c),
+        }
+    }
+    let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    decode_entities(&collapsed)
+}
+
+fn decode_entities(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&hellip;", "…")
+        .replace("&nbsp;", " ")
+}
+
+/// Truncate to at most `max` chars (char-safe), appending `…` when cut.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // --- strip_html / decode_entities / truncate ---------------------------
+
+    #[test]
+    fn strip_html_removes_tags_and_collapses_whitespace() {
+        let html = "<p>Hello   <b>world</b></p>\n<p>second</p>";
+        assert_eq!(strip_html(html), "Hello world second");
+    }
+
+    #[test]
+    fn strip_html_decodes_common_entities() {
+        let html = "<p>Tom &amp; Jerry said &quot;hi&quot; &lt;here&gt;</p>";
+        assert_eq!(strip_html(html), "Tom & Jerry said \"hi\" <here>");
+    }
+
+    #[test]
+    fn strip_html_on_plain_text_is_identity_modulo_whitespace() {
+        assert_eq!(strip_html("just text"), "just text");
+    }
+
+    #[test]
+    fn truncate_leaves_short_strings_untouched() {
+        assert_eq!(truncate("short", 10), "short");
+    }
+
+    #[test]
+    fn truncate_cuts_and_appends_ellipsis() {
+        let out = truncate("abcdefghij", 5);
+        assert_eq!(out, "abcde…");
+    }
+
+    #[test]
+    fn truncate_is_char_safe_on_multibyte() {
+        // Five multibyte chars, limit 3 — must not panic on a byte boundary.
+        let out = truncate("äöåüö", 3);
+        assert_eq!(out, "äöå…");
+    }
+
+    #[test]
+    fn blurb_for_topic_matches_by_topic_id() {
+        let posts = vec![
+            json!({"topic_id": 1, "blurb": "first"}),
+            json!({"topic_id": 2, "blurb": "second"}),
+        ];
+        assert_eq!(blurb_for_topic(&posts, 2).as_deref(), Some("second"));
+        assert_eq!(blurb_for_topic(&posts, 99), None);
+    }
+
+    // --- renderers ---------------------------------------------------------
+
+    #[test]
+    fn render_search_lists_topics_with_blurbs() {
+        let v = json!({
+            "topics": [{"id": 42, "title": "Revenue beat", "posts_count": 7}],
+            "posts": [{"topic_id": 42, "blurb": "<b>Strong</b> quarter"}]
+        });
+        let out = render_search(&v);
+        assert!(out.contains("#42"));
+        assert!(out.contains("Revenue beat"));
+        assert!(out.contains("7 posts"));
+        // Blurb HTML is stripped.
+        assert!(out.contains("Strong quarter"));
+        assert!(!out.contains("<b>"));
+        assert!(out.contains("inderes forum topic"));
+    }
+
+    #[test]
+    fn render_search_handles_no_results() {
+        assert_eq!(
+            render_search(&json!({"topics": []})),
+            "No matching topics.\n"
+        );
+        assert_eq!(render_search(&json!({})), "No matching topics.\n");
+    }
+
+    #[test]
+    fn render_topic_shows_full_post_bodies() {
+        let v = json!({
+            "id": 5,
+            "title": "Outlook",
+            "post_stream": {"posts": [
+                {"post_number": 1, "username": "alice", "created_at": "2026-01-02",
+                 "cooked": "<p>Bullish on margins</p>"},
+                {"post_number": 2, "username": "bob", "created_at": "2026-01-03",
+                 "cooked": "<p>Disagree</p>"}
+            ]}
+        });
+        let out = render_topic(&v);
+        assert!(out.contains("Outlook"));
+        assert!(out.contains("topic #5"));
+        assert!(out.contains("#1 @alice (2026-01-02):"));
+        assert!(out.contains("Bullish on margins"));
+        assert!(out.contains("#2 @bob"));
+        assert!(out.contains("Disagree"));
+        assert!(!out.contains("<p>"));
+    }
+
+    #[test]
+    fn render_topic_handles_empty_stream() {
+        let out = render_topic(&json!({"title": "Empty", "post_stream": {"posts": []}}));
+        assert!(out.contains("Empty"));
+        assert!(out.contains("(no posts)"));
+    }
+
+    #[test]
+    fn render_latest_lists_topics() {
+        let v = json!({"topic_list": {"topics": [
+            {"id": 9, "title": "Daily thread", "posts_count": 120, "views": 4000}
+        ]}});
+        let out = render_latest(&v);
+        assert!(out.contains("#9"));
+        assert!(out.contains("Daily thread"));
+        assert!(out.contains("120 posts"));
+        assert!(out.contains("4000 views"));
+    }
+
+    #[test]
+    fn render_categories_lists_names_and_descriptions() {
+        let v = json!({"category_list": {"categories": [
+            {"name": "Osakkeet", "slug": "osakkeet", "topic_count": 800,
+             "description_text": "Keskustelua osakkeista"}
+        ]}});
+        let out = render_categories(&v);
+        assert!(out.contains("Osakkeet"));
+        assert!(out.contains("[osakkeet]"));
+        assert!(out.contains("800 topics"));
+        assert!(out.contains("Keskustelua osakkeista"));
+    }
+
+    // --- ForumClient (wiremock) -------------------------------------------
+
+    #[tokio::test]
+    async fn search_hits_search_endpoint_with_query() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search.json"))
+            .and(query_param("q", "nokia"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "topics": [{"id": 1, "title": "Nokia", "posts_count": 3}],
+                "posts": []
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let http = reqwest::Client::new();
+        let client = ForumClient::new(&http, &server.uri());
+        let v = client.search("nokia").await.unwrap();
+        assert_eq!(v["topics"][0]["title"], "Nokia");
+    }
+
+    #[tokio::test]
+    async fn topic_hits_topic_path() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/t/123.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": 123, "title": "Topic", "post_stream": {"posts": []}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let http = reqwest::Client::new();
+        let client = ForumClient::new(&http, &server.uri());
+        let v = client.topic("123").await.unwrap();
+        assert_eq!(v["id"], 123);
+    }
+
+    #[tokio::test]
+    async fn non_success_status_is_an_error_without_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/t/404.json"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("<html>big error page</html>"))
+            .mount(&server)
+            .await;
+
+        let http = reqwest::Client::new();
+        let client = ForumClient::new(&http, &server.uri());
+        let err = client.topic("404").await.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("404"), "got: {msg}");
+        // The HTML body must not leak into the error.
+        assert!(!msg.contains("big error page"), "got: {msg}");
+    }
+
+    #[test]
+    fn new_trims_trailing_slash_from_base() {
+        let http = reqwest::Client::new();
+        let client = ForumClient::new(&http, "https://forum.example.com/");
+        assert_eq!(client.base, "https://forum.example.com");
+    }
+}

--- a/src/forum.rs
+++ b/src/forum.rs
@@ -81,10 +81,18 @@ impl<'a> ForumClient<'a> {
         self.get_json("/search.json", &[("q", query)]).await
     }
 
-    /// A single topic with its post stream (`/t/<id>.json`).
-    pub async fn topic(&self, id: &str) -> Result<Value> {
+    /// A single topic with its post stream (`/t/<id>.json`). `page` is 1-based;
+    /// Discourse returns ~20 posts per page, so pass 2, 3, … to walk a long
+    /// thread. Page 1 is sent without the query param so it matches the bare URL.
+    pub async fn topic(&self, id: &str, page: u32) -> Result<Value> {
         let path = format!("/t/{id}.json");
-        self.get_json(&path, &[]).await
+        let page_s = page.to_string();
+        let query: Vec<(&str, &str)> = if page > 1 {
+            vec![("page", page_s.as_str())]
+        } else {
+            Vec::new()
+        };
+        self.get_json(&path, &query).await
     }
 
     /// Latest active topics (`/latest.json`).
@@ -268,7 +276,7 @@ fn truncate(s: &str, max: usize) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
-    use wiremock::matchers::{method, path, query_param};
+    use wiremock::matchers::{method, path, query_param, query_param_is_missing};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     // --- strip_html / decode_entities / truncate ---------------------------
@@ -422,10 +430,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn topic_hits_topic_path() {
+    async fn topic_page_1_omits_the_page_query_param() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/t/123.json"))
+            .and(query_param_is_missing("page"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "id": 123, "title": "Topic", "post_stream": {"posts": []}
             })))
@@ -435,8 +444,30 @@ mod tests {
 
         let http = reqwest::Client::new();
         let client = ForumClient::new(&http, &server.uri());
-        let v = client.topic("123").await.unwrap();
+        let v = client.topic("123", 1).await.unwrap();
         assert_eq!(v["id"], 123);
+    }
+
+    #[tokio::test]
+    async fn topic_page_n_sends_the_page_query_param() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/t/123.json"))
+            .and(query_param("page", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": 123, "title": "T",
+                "post_stream": {"posts": [
+                    {"post_number": 21, "username": "u", "cooked": "<p>x</p>"}
+                ]}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let http = reqwest::Client::new();
+        let client = ForumClient::new(&http, &server.uri());
+        let v = client.topic("123", 2).await.unwrap();
+        assert_eq!(v["post_stream"]["posts"][0]["post_number"], 21);
     }
 
     #[tokio::test]
@@ -450,7 +481,7 @@ mod tests {
 
         let http = reqwest::Client::new();
         let client = ForumClient::new(&http, &server.uri());
-        let err = client.topic("404").await.unwrap_err();
+        let err = client.topic("404", 1).await.unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("404"), "got: {msg}");
         // The HTML body must not leak into the error.

--- a/src/forum.rs
+++ b/src/forum.rs
@@ -10,7 +10,7 @@
 //! downstream work — e.g. sentiment analysis over posts — should use `--json`
 //! to get the raw Discourse fields (`cooked`, `created_at`, `username`, …).
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use serde_json::Value;
 
 /// Public Discourse instance. Overridable via `INDERES_FORUM_URL` (used by
@@ -52,18 +52,20 @@ impl<'a> ForumClient<'a> {
         let status = resp.status();
         // A 401/403 on an anonymous read is the signature of the forum being
         // switched to login-required (Discourse `login_required`). Diagnose it
-        // explicitly rather than emitting a bare status — there is nothing the
-        // user can do in this CLI to fix it (the forum's User-API-Key feature
-        // is disabled), so point them at the actual lever.
+        // explicitly rather than emitting a bare status. Name the actual base
+        // (overridable via INDERES_FORUM_URL) and keep the advice generic so a
+        // self-hosted mirror isn't told to "ask Inderes".
         if matches!(
             status,
             reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
         ) {
             bail!(
-                "forum.inderes.com denied anonymous access (HTTP {status}) — the forum may now \
-                 require login. This CLI reads the forum anonymously; its User-API-Key feature \
-                 is disabled, so authenticated access isn't currently possible. Ask Inderes to \
-                 enable it."
+                "{} denied anonymous access (HTTP {status}) — the forum may require login. \
+                 This CLI reads the forum anonymously and cannot authenticate: Discourse only \
+                 accepts a session cookie or a User-API-Key, and the public Inderes forum has \
+                 its User-API-Key feature disabled. Ask the forum administrators to enable it \
+                 for programmatic access.",
+                self.base
             );
         }
         // Body is intentionally kept out of the error: Discourse error pages
@@ -72,8 +74,18 @@ impl<'a> ForumClient<'a> {
             bail!("forum request to {path} returned HTTP {status}");
         }
         let body = resp.text().await.unwrap_or_default();
-        serde_json::from_str(&body)
-            .with_context(|| format!("parsing forum JSON response from {path}"))
+        serde_json::from_str(&body).map_err(|e| {
+            // A 200 carrying HTML (CDN / maintenance / login interstitial) is the
+            // common non-JSON case — say so instead of a bare parse error.
+            if body.trim_start().starts_with('<') {
+                anyhow!(
+                    "forum returned a non-JSON response from {path} (HTTP {status}) — likely an \
+                     HTML page (CDN, maintenance, or login interstitial), not the JSON API"
+                )
+            } else {
+                anyhow!("parsing forum JSON response from {path}: {e}")
+            }
+        })
     }
 
     /// Full-text search across topics and posts (`/search.json?q=`).
@@ -85,6 +97,11 @@ impl<'a> ForumClient<'a> {
     /// Discourse returns ~20 posts per page, so pass 2, 3, … to walk a long
     /// thread. Page 1 is sent without the query param so it matches the bare URL.
     pub async fn topic(&self, id: &str, page: u32) -> Result<Value> {
+        // Topic ids are integers; reject anything else so a stray slug or path
+        // segment fails clearly instead of producing a confusing request.
+        if id.is_empty() || !id.bytes().all(|b| b.is_ascii_digit()) {
+            bail!("invalid topic id {id:?}: expected a number (the id in a /t/<slug>/<id> URL)");
+        }
         let path = format!("/t/{id}.json");
         let page_s = page.to_string();
         let query: Vec<(&str, &str)> = if page > 1 {
@@ -114,11 +131,15 @@ impl<'a> ForumClient<'a> {
 /// Search results: one line per matched topic, with a stripped blurb from the
 /// best-matching post when Discourse supplies one.
 pub fn render_search(v: &Value) -> String {
-    let topics = v.get("topics").and_then(Value::as_array);
-    let posts = v.get("posts").and_then(Value::as_array);
-    let Some(topics) = topics.filter(|t| !t.is_empty()) else {
-        return "No matching topics.\n".to_string();
+    // Missing `topics` key = unexpected shape (dump raw); present-but-empty =
+    // a genuine no-results.
+    let Some(topics) = v.get("topics").and_then(Value::as_array) else {
+        return fallback_json(v);
     };
+    if topics.is_empty() {
+        return "No matching topics.\n".to_string();
+    }
+    let posts = v.get("posts").and_then(Value::as_array);
     let mut out = String::new();
     for t in topics {
         let id = t.get("id").and_then(Value::as_i64).unwrap_or(0);
@@ -140,6 +161,15 @@ pub fn render_search(v: &Value) -> String {
 /// stripped). Full bodies — not truncated — because the post text is the
 /// payload for downstream analysis.
 pub fn render_topic(v: &Value) -> String {
+    // No post_stream.posts at all = unexpected shape; dump raw JSON instead of
+    // masquerading as an empty topic.
+    let Some(posts) = v
+        .get("post_stream")
+        .and_then(|s| s.get("posts"))
+        .and_then(Value::as_array)
+    else {
+        return fallback_json(v);
+    };
     let title = v
         .get("title")
         .and_then(Value::as_str)
@@ -150,14 +180,10 @@ pub fn render_topic(v: &Value) -> String {
     }
     out.push('\n');
 
-    let posts = v
-        .get("post_stream")
-        .and_then(|s| s.get("posts"))
-        .and_then(Value::as_array);
-    let Some(posts) = posts.filter(|p| !p.is_empty()) else {
+    if posts.is_empty() {
         out.push_str("(no posts)\n");
         return out;
-    };
+    }
     for p in posts {
         let n = p.get("post_number").and_then(Value::as_i64).unwrap_or(0);
         let who = p.get("username").and_then(Value::as_str).unwrap_or("?");
@@ -172,13 +198,16 @@ pub fn render_topic(v: &Value) -> String {
 
 /// Latest topics list (`topic_list.topics`).
 pub fn render_latest(v: &Value) -> String {
-    let topics = v
+    let Some(topics) = v
         .get("topic_list")
         .and_then(|l| l.get("topics"))
-        .and_then(Value::as_array);
-    let Some(topics) = topics.filter(|t| !t.is_empty()) else {
-        return "No topics.\n".to_string();
+        .and_then(Value::as_array)
+    else {
+        return fallback_json(v);
     };
+    if topics.is_empty() {
+        return "No topics.\n".to_string();
+    }
     let mut out = String::new();
     for t in topics {
         let id = t.get("id").and_then(Value::as_i64).unwrap_or(0);
@@ -196,13 +225,16 @@ pub fn render_latest(v: &Value) -> String {
 
 /// Categories list (`category_list.categories`).
 pub fn render_categories(v: &Value) -> String {
-    let cats = v
+    let Some(cats) = v
         .get("category_list")
         .and_then(|l| l.get("categories"))
-        .and_then(Value::as_array);
-    let Some(cats) = cats.filter(|c| !c.is_empty()) else {
-        return "No categories.\n".to_string();
+        .and_then(Value::as_array)
+    else {
+        return fallback_json(v);
     };
+    if cats.is_empty() {
+        return "No categories.\n".to_string();
+    }
     let mut out = String::new();
     for c in cats {
         let name = c.get("name").and_then(Value::as_str).unwrap_or("(unnamed)");
@@ -216,6 +248,15 @@ pub fn render_categories(v: &Value) -> String {
         }
     }
     out
+}
+
+/// Fallback for an unrecognized response shape: show the raw JSON so a silent
+/// upstream change surfaces instead of masquerading as an empty result.
+fn fallback_json(v: &Value) -> String {
+    format!(
+        "(unrecognized forum response shape — showing raw JSON; pass --json for the same)\n{}\n",
+        serde_json::to_string_pretty(v).unwrap_or_default()
+    )
 }
 
 // --- pure helpers ----------------------------------------------------------
@@ -235,12 +276,22 @@ fn blurb_for_topic(posts: &[Value], topic_id: i64) -> Option<String> {
     })
 }
 
-/// Best-effort HTML → text: drop tags, collapse whitespace, decode the handful
-/// of entities Discourse emits. Not a parser; good enough for terminal reading.
+/// Best-effort HTML → text for terminal reading: map block boundaries to
+/// newlines (so multi-paragraph posts stay readable), drop remaining tags,
+/// collapse intra-line whitespace while keeping line breaks, then decode the
+/// handful of entities Discourse emits. Not a parser.
 fn strip_html(s: &str) -> String {
-    let mut text = String::with_capacity(s.len());
+    let with_breaks = s
+        .replace("</p>", "\n\n")
+        .replace("<br>", "\n")
+        .replace("<br/>", "\n")
+        .replace("<br />", "\n")
+        .replace("</li>", "\n")
+        .replace("</blockquote>", "\n");
+
+    let mut text = String::with_capacity(with_breaks.len());
     let mut in_tag = false;
-    for c in s.chars() {
+    for c in with_breaks.chars() {
         match c {
             '<' => in_tag = true,
             '>' => in_tag = false,
@@ -248,18 +299,33 @@ fn strip_html(s: &str) -> String {
             _ => text.push(c),
         }
     }
-    let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    decode_entities(&collapsed)
+
+    // Collapse whitespace within each line but keep newlines; drop leading and
+    // consecutive blank lines so the output isn't riddled with gaps.
+    let mut lines: Vec<String> = Vec::new();
+    for line in text.lines() {
+        let collapsed = line.split_whitespace().collect::<Vec<_>>().join(" ");
+        if collapsed.is_empty() && lines.last().is_none_or(|l: &String| l.is_empty()) {
+            continue;
+        }
+        lines.push(collapsed);
+    }
+    while lines.last().is_some_and(|l| l.is_empty()) {
+        lines.pop();
+    }
+    decode_entities(&lines.join("\n"))
 }
 
 fn decode_entities(s: &str) -> String {
-    s.replace("&amp;", "&")
-        .replace("&lt;", "<")
+    // `&amp;` must be decoded LAST: decoding it first would turn an encoded
+    // reference like "&amp;gt;" into "&gt;" and then into ">", double-decoding it.
+    s.replace("&lt;", "<")
         .replace("&gt;", ">")
         .replace("&quot;", "\"")
         .replace("&#39;", "'")
         .replace("&hellip;", "…")
         .replace("&nbsp;", " ")
+        .replace("&amp;", "&")
 }
 
 /// Truncate to at most `max` chars (char-safe), appending `…` when cut.
@@ -282,9 +348,23 @@ mod tests {
     // --- strip_html / decode_entities / truncate ---------------------------
 
     #[test]
-    fn strip_html_removes_tags_and_collapses_whitespace() {
+    fn strip_html_collapses_intra_line_whitespace_but_keeps_paragraphs() {
+        // Tags gone, runs of spaces collapsed, but the paragraph break between
+        // the two <p> blocks is preserved (one blank line).
         let html = "<p>Hello   <b>world</b></p>\n<p>second</p>";
-        assert_eq!(strip_html(html), "Hello world second");
+        assert_eq!(strip_html(html), "Hello world\n\nsecond");
+    }
+
+    #[test]
+    fn strip_html_converts_br_to_newline() {
+        assert_eq!(strip_html("line one<br>line two"), "line one\nline two");
+    }
+
+    #[test]
+    fn decode_entities_does_not_double_decode_amp() {
+        // "&amp;gt;" encodes the literal text "&gt;" — it must decode to "&gt;",
+        // not ">". Regression guard for &amp; being decoded before &gt;.
+        assert_eq!(strip_html("&amp;gt;"), "&gt;");
     }
 
     #[test]
@@ -345,12 +425,27 @@ mod tests {
     }
 
     #[test]
-    fn render_search_handles_no_results() {
+    fn render_search_empty_topics_is_a_genuine_no_result() {
+        // `topics` present but empty = no matches.
         assert_eq!(
             render_search(&json!({"topics": []})),
             "No matching topics.\n"
         );
-        assert_eq!(render_search(&json!({})), "No matching topics.\n");
+    }
+
+    #[test]
+    fn render_unrecognized_shape_dumps_raw_json_not_a_fake_empty() {
+        // `topics`/`topic_list`/`category_list`/`post_stream` missing entirely =
+        // unexpected shape; surface it instead of pretending it's empty.
+        for out in [
+            render_search(&json!({"unexpected": 1})),
+            render_latest(&json!({"unexpected": 1})),
+            render_categories(&json!({"unexpected": 1})),
+            render_topic(&json!({"unexpected": 1})),
+        ] {
+            assert!(out.contains("unrecognized"), "got: {out}");
+            assert!(out.contains("unexpected"), "got: {out}");
+        }
     }
 
     #[test]
@@ -486,6 +581,40 @@ mod tests {
         assert!(msg.contains("404"), "got: {msg}");
         // The HTML body must not leak into the error.
         assert!(!msg.contains("big error page"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn topic_rejects_non_numeric_id() {
+        // No network needed — validation happens before the request.
+        let http = reqwest::Client::new();
+        let client = ForumClient::new(&http, "https://example.com");
+        let err = client.topic("../latest", 1).await.unwrap_err();
+        assert!(
+            format!("{err:#}").contains("invalid topic id"),
+            "got: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn html_200_is_reported_as_non_json() {
+        // A 200 carrying an HTML interstitial must produce a clear diagnostic,
+        // not a bare serde parse error, and must not leak the HTML body.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/latest.json"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("<html><body>DO_NOT_LEAK_42</body></html>"),
+            )
+            .mount(&server)
+            .await;
+
+        let http = reqwest::Client::new();
+        let client = ForumClient::new(&http, &server.uri());
+        let err = client.latest().await.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("non-JSON"), "got: {msg}");
+        assert!(!msg.contains("DO_NOT_LEAK_42"), "got: {msg}");
     }
 
     #[tokio::test]

--- a/src/forum.rs
+++ b/src/forum.rs
@@ -50,6 +50,22 @@ impl<'a> ForumClient<'a> {
             .await
             .with_context(|| format!("GET {url}"))?;
         let status = resp.status();
+        // A 401/403 on an anonymous read is the signature of the forum being
+        // switched to login-required (Discourse `login_required`). Diagnose it
+        // explicitly rather than emitting a bare status — there is nothing the
+        // user can do in this CLI to fix it (the forum's User-API-Key feature
+        // is disabled), so point them at the actual lever.
+        if matches!(
+            status,
+            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+        ) {
+            bail!(
+                "forum.inderes.com denied anonymous access (HTTP {status}) — the forum may now \
+                 require login. This CLI reads the forum anonymously; its User-API-Key feature \
+                 is disabled, so authenticated access isn't currently possible. Ask Inderes to \
+                 enable it."
+            );
+        }
         // Body is intentionally kept out of the error: Discourse error pages
         // can be large HTML, and we never want to splatter that at the user.
         if !status.is_success() {
@@ -439,6 +455,25 @@ mod tests {
         assert!(msg.contains("404"), "got: {msg}");
         // The HTML body must not leak into the error.
         assert!(!msg.contains("big error page"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn forbidden_is_diagnosed_as_login_required() {
+        // The signature of the forum being flipped to login-required: an
+        // anonymous read returns 403. We must explain it, not just echo 403.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/latest.json"))
+            .respond_with(ResponseTemplate::new(403).set_body_string(r#"{"errors":["nope"]}"#))
+            .mount(&server)
+            .await;
+
+        let http = reqwest::Client::new();
+        let client = ForumClient::new(&http, &server.uri());
+        let err = client.latest().await.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("require login"), "got: {msg}");
+        assert!(msg.contains("User-API-Key"), "got: {msg}");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,6 +217,10 @@ enum ForumCmd {
     Topic {
         /// Numeric topic ID (the number in a /t/<slug>/<id> URL).
         id: String,
+        /// Page of posts to fetch (~20 per page, 1-based). Discourse paginates
+        /// long threads; pass 2, 3, … to read past the first page.
+        #[arg(long, default_value_t = 1)]
+        page: u32,
     },
     /// List the latest active topics.
     Latest,
@@ -329,7 +333,9 @@ async fn run() -> Result<()> {
         }) => commands::documents_read(&ctx, &document_id, sections).await,
 
         Command::Forum(ForumCmd::Search { query }) => commands::forum_search(&ctx, &query).await,
-        Command::Forum(ForumCmd::Topic { id }) => commands::forum_topic(&ctx, &id).await,
+        Command::Forum(ForumCmd::Topic { id, page }) => {
+            commands::forum_topic(&ctx, &id, page).await
+        }
         Command::Forum(ForumCmd::Latest) => commands::forum_latest(&ctx).await,
         Command::Forum(ForumCmd::Categories) => commands::forum_categories(&ctx).await,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 
 mod auth;
 mod commands;
+mod forum;
 mod mcp;
 mod oauth;
 mod skill;
@@ -119,6 +120,10 @@ enum Command {
     #[command(subcommand)]
     Documents(DocumentsCmd),
 
+    /// Read the public Inderes forum (forum.inderes.com). No login required.
+    #[command(subcommand)]
+    Forum(ForumCmd),
+
     /// Low-level: call any MCP tool directly.
     Call {
         /// Tool name (e.g. list-transcripts). Omit when using --list.
@@ -199,6 +204,24 @@ enum ContentCmd {
         #[arg(long)]
         lang: Option<String>,
     },
+}
+
+#[derive(Debug, Subcommand)]
+enum ForumCmd {
+    /// Full-text search across forum topics and posts.
+    Search {
+        /// Free-text query.
+        query: String,
+    },
+    /// Show a topic and its posts by numeric topic ID.
+    Topic {
+        /// Numeric topic ID (the number in a /t/<slug>/<id> URL).
+        id: String,
+    },
+    /// List the latest active topics.
+    Latest,
+    /// List forum categories.
+    Categories,
 }
 
 #[derive(Debug, Subcommand)]
@@ -304,6 +327,11 @@ async fn run() -> Result<()> {
             document_id,
             sections,
         }) => commands::documents_read(&ctx, &document_id, sections).await,
+
+        Command::Forum(ForumCmd::Search { query }) => commands::forum_search(&ctx, &query).await,
+        Command::Forum(ForumCmd::Topic { id }) => commands::forum_topic(&ctx, &id).await,
+        Command::Forum(ForumCmd::Latest) => commands::forum_latest(&ctx).await,
+        Command::Forum(ForumCmd::Categories) => commands::forum_categories(&ctx).await,
 
         Command::Call {
             tool,

--- a/src/skill/hermes.md
+++ b/src/skill/hermes.md
@@ -45,6 +45,19 @@ Then call a friendly subcommand:
 
 Append `--json` on any subcommand to get raw JSON (easier to post-process).
 
+## Forum (public, no login)
+
+`inderes forum` reads the public Inderes forum (forum.inderes.com) directly — **no `inderes login` required**; it sends no credentials. Use it for community/retail sentiment and discussion, as distinct from analyst research.
+
+```bash
+inderes forum search "Nokia"   # full-text search across topics and posts
+inderes forum topic 74         # a topic's posts (page 1; --page N for more)
+inderes forum latest           # latest active topics
+inderes forum categories       # category list
+```
+
+Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns ~20 posts per page; pass `--page N` (1-based) to walk longer threads. This is separate from the authenticated MCP tool `inderes call search-forum-topics`.
+
 ## Procedure
 
 1. Parse what the user needs — fundamentals, estimates, a specific report, an event, an insider trade, etc.

--- a/src/skill/openclaw.md
+++ b/src/skill/openclaw.md
@@ -43,6 +43,19 @@ Then call one of the friendly subcommands, or drop down to `inderes call <tool>`
 
 Pass `--json` to any of the above to get raw JSON (useful when you need to extract structured data).
 
+## Forum (public, no login)
+
+`inderes forum` reads the public Inderes forum (forum.inderes.com) directly — **no `inderes login` required**; it sends no credentials. Use it for community/retail sentiment and discussion, as distinct from analyst research.
+
+```bash
+inderes forum search "Nokia"   # full-text search across topics and posts
+inderes forum topic 74         # a topic's posts (page 1; --page N for more)
+inderes forum latest           # latest active topics
+inderes forum categories       # category list
+```
+
+Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns ~20 posts per page; pass `--page N` (1-based) to walk longer threads. This is separate from the authenticated MCP tool `inderes call search-forum-topics`.
+
 ## Escape hatch: all 16 tools
 
 The server exposes more tools than the friendly subcommands wrap. To see everything:

--- a/src/skill/ptrclaw.md
+++ b/src/skill/ptrclaw.md
@@ -40,6 +40,19 @@ Then call a friendly subcommand:
 
 Append `--json` on any subcommand to get raw JSON (easier to post-process).
 
+## Forum (public, no login)
+
+`inderes forum` reads the public Inderes forum (forum.inderes.com) directly — **no `inderes login` required**; it sends no credentials. Use it for community/retail sentiment and discussion, as distinct from analyst research.
+
+```bash
+inderes forum search "Nokia"   # full-text search across topics and posts
+inderes forum topic 74         # a topic's posts (page 1; --page N for more)
+inderes forum latest           # latest active topics
+inderes forum categories       # category list
+```
+
+Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns ~20 posts per page; pass `--page N` (1-based) to walk longer threads. This is separate from the authenticated MCP tool `inderes call search-forum-topics`.
+
 ## Procedure
 
 1. Parse what the user needs — fundamentals, estimates, a specific report, an event, an insider trade, etc.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -26,6 +26,7 @@ fn isolated() -> (Command, TempDir) {
     cmd.env_remove("INDERES_IDP_TOKEN_URL");
     cmd.env_remove("INDERES_IDP_USERINFO_URL");
     cmd.env_remove("INDERES_IDP_CLIENT_ID");
+    cmd.env_remove("INDERES_FORUM_URL");
     (cmd, tmp)
 }
 
@@ -52,12 +53,22 @@ fn help_lists_all_subcommands() {
         "estimates",
         "content",
         "documents",
+        "forum",
         "call",
         "install-skill",
         "completions",
     ];
     let mut assertion = cmd.arg("--help").assert().success();
     for sub in expected {
+        assertion = assertion.stdout(predicate::str::contains(sub));
+    }
+}
+
+#[test]
+fn forum_help_lists_subcommands() {
+    let (mut cmd, _tmp) = isolated();
+    let mut assertion = cmd.args(["forum", "--help"]).assert().success();
+    for sub in ["search", "topic", "latest", "categories"] {
         assertion = assertion.stdout(predicate::str::contains(sub));
     }
 }


### PR DESCRIPTION
## What

Adds an `inderes forum` command group that reads the public Discourse JSON API at
`forum.inderes.com` — no authentication required.

| Command | Endpoint | Output |
|---|---|---|
| `forum search <query>` | `/search.json?q=` | matched topics + stripped blurbs |
| `forum topic <id>` | `/t/<id>.json` | title + post bodies (first page) |
| `forum latest` | `/latest.json` | latest active topics |
| `forum categories` | `/categories.json` | category list |

All support `--json` for raw Discourse fields (for agent/scripting use, e.g.
downstream sentiment analysis over `cooked`/`username`/`created_at`).

## Why no auth

The forum is a separate application from the MCP server. It logs in via the same
Keycloak realm but a different OIDC client (`keskustelut-inderes-fi`), and the
result is a Discourse session cookie — not a reusable token. The `inderes-mcp`
Keycloak token is not valid forum credentials, and the Discourse User-API-Key
feature (the supported third-party path) is disabled on the forum. So this path
sends no credentials and only reads public content, which is sufficient: the
forum is open to all.

If the forum is later switched to login-required, anonymous reads return 401/403;
the client detects that and prints an actionable message instead of a bare status.

## Notes / scope

- `forum topic <id>` returns the first page of a topic (~20 posts). Full-topic
  pagination (walking `post_stream.stream`) is deferred to a follow-up that pairs
  it with a local cache.
- Base URL overridable via `INDERES_FORUM_URL`.
- Also includes a docs commit adding process rules + the code-review workflow to
  CLAUDE.md.

## Testing

- New `src/forum.rs` module with unit tests (HTML stripping, truncation,
  renderers) and wiremock tests (endpoint routing, 404 without body leak,
  401/403 login-required diagnosis).
- Integration test for `forum --help`.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test
  --all-targets` (131 tests) and markdownlint all clean.
- Smoke-tested against the live forum (search/categories/latest return real data).
