### PR TITLE
feat(forum): SQLite read-through cache for topic reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +424,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -576,7 +594,16 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -584,6 +611,18 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
+dependencies = [
+ "hashbrown 0.17.0",
+]
 
 [[package]]
 name = "heck"
@@ -835,6 +874,7 @@ dependencies = [
  "predicates",
  "rand 0.10.1",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -974,6 +1014,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1126,6 +1177,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1418,6 +1475,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1716,18 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2014,6 +2108,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ webbrowser = "1"
 futures-util = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+rusqlite = { version = "0.40.1", features = ["bundled"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ inderes --json search "Nokia" | jq '.content[0].text'
 `inderes forum` reads the public [Inderes forum](https://forum.inderes.com) (a Discourse instance) directly over its JSON API. This path is **independent of the MCP server and Keycloak** — it sends no credentials and reads only public content, so it works before (and without) `inderes login`.
 
 ```bash
-inderes forum search "Nokia"   # full-text search across topics and posts
-inderes forum topic 74         # a topic's posts (page 1)
-inderes forum topic 74 --page 2  # next page (~20 posts) of a long thread
-inderes forum latest           # latest active topics
-inderes forum categories       # category list
+inderes forum search "Nokia"      # full-text search across topics and posts
+inderes forum topic 74            # full thread, cached locally (see below)
+inderes forum topic 74 --refresh  # re-fetch the whole thread, replacing the cache
+inderes forum latest              # latest active topics
+inderes forum categories          # category list
 ```
 
 `--json` emits the raw Discourse fields (`cooked`, `username`, `created_at`, …), handy for scripting or downstream analysis:
@@ -139,9 +139,9 @@ inderes forum categories       # category list
 inderes --json forum topic 74 | jq '.post_stream.posts[].cooked'
 ```
 
-> **Why no login.** The forum is open to all, so authentication isn't required — and isn't currently possible anyway: the forum signs in via the same Keycloak but issues a Discourse session cookie rather than a reusable token, and its third-party User-API-Key feature is disabled. If the forum is ever switched to login-required, anonymous reads return 401/403 and the CLI reports that explicitly instead of failing cryptically. Point the forum base elsewhere with `INDERES_FORUM_URL`.
+> **Read-through cache.** `forum topic <id>` is backed by a local SQLite cache: each call fetches only the posts added since last time, stores them, and serves the whole thread from disk — so re-reads are instant and a long thread is downloaded only once. The first call on a very long thread walks every page; it's resumable, so if it's interrupted or rate-limited, just re-run to continue. `--refresh` re-fetches from page 1 (picks up edited or deleted posts). The DB lives at the platform data dir; override with `INDERES_FORUM_DB`. Beyond avoiding re-downloads, the cache is a queryable corpus — posts land in real columns (`username`, `created_at`, `post_number`, `cooked`) for local analysis. Listings (search/latest/categories) are always live, never cached.
 >
-> **Note.** `forum topic <id>` returns ~20 posts per page; pass `--page N` (1-based) to walk a longer thread. There is no auto-fetch-all flag yet — bulk corpus retrieval is planned alongside a local cache.
+> **Why no login.** The forum is open to all, so authentication isn't required — and isn't currently possible anyway: the forum signs in via the same Keycloak but issues a Discourse session cookie rather than a reusable token, and its third-party User-API-Key feature is disabled. If the forum is ever switched to login-required, anonymous reads return 401/403 and the CLI reports that explicitly instead of failing cryptically. Point the forum base elsewhere with `INDERES_FORUM_URL`.
 
 ## Upgrade
 
@@ -194,6 +194,7 @@ inderes completions powershell | Out-String | Invoke-Expression
 |---|---|---|
 | `--endpoint` / `INDERES_MCP_ENDPOINT` | Override the MCP HTTP endpoint | `https://mcp.inderes.com/` |
 | `INDERES_FORUM_URL` | Override the forum base URL used by `inderes forum` | `https://forum.inderes.com` |
+| `INDERES_FORUM_DB` | Override the SQLite cache path for `inderes forum topic` | platform data dir |
 | `--json` | Emit raw JSON from MCP tool calls | off |
 | `-v` / `-vv` | Increase logging verbosity (`warn` → `info` → `debug`) | `warn` |
 | `INDERES_LOG` | `tracing` env filter (overrides `-v`) | unset |
@@ -224,6 +225,7 @@ Written atomically (tempfile + rename) so a crash can't leave a half-written fil
 - `src/mcp.rs` — MCP 2025-03-26 Streamable HTTP client, handles both `application/json` and `text/event-stream` responses.
 - `src/commands.rs` — subcommand implementations and output formatting.
 - `src/forum.rs` — read-only Discourse JSON client for the public forum (no auth, independent of MCP).
+- `src/cache.rs` — local SQLite read-through cache + queryable corpus for forum topic posts.
 - `src/skill/{openclaw,hermes,ptrclaw}.md` — embedded at compile time; `inderes install-skill <host>` writes the right one to disk.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ inderes --json search "Nokia" | jq '.content[0].text'
 ```bash
 inderes forum search "Nokia"      # full-text search across topics and posts
 inderes forum topic 74            # full thread, cached locally (see below)
-inderes forum topic 74 --refresh  # re-fetch the whole thread, replacing the cache
+inderes forum topic 74 --refresh  # re-fetch from page 1, updating edited posts
 inderes forum latest              # latest active topics
 inderes forum categories          # category list
 ```
@@ -139,7 +139,7 @@ inderes forum categories          # category list
 inderes --json forum topic 74 | jq '.post_stream.posts[].cooked'
 ```
 
-> **Read-through cache.** `forum topic <id>` is backed by a local SQLite cache: each call fetches only the posts added since last time, stores them, and serves the whole thread from disk — so re-reads are instant and a long thread is downloaded only once. The first call on a very long thread walks every page; it's resumable, so if it's interrupted or rate-limited, just re-run to continue. `--refresh` re-fetches from page 1 (picks up edited or deleted posts). The DB lives at the platform data dir; override with `INDERES_FORUM_DB`. Beyond avoiding re-downloads, the cache is a queryable corpus — posts land in real columns (`username`, `created_at`, `post_number`, `cooked`) for local analysis. Listings (search/latest/categories) are always live, never cached.
+> **Read-through cache.** `forum topic <id>` is backed by a local SQLite cache: each call fetches only the posts added since last time, stores them, and serves the whole thread from disk — so re-reads are instant and a long thread is downloaded only once. The first call on a very long thread walks every page; it's resumable, so if it's interrupted or rate-limited, just re-run to continue. `--refresh` re-walks from page 1 to pick up edits to older posts — it upserts rather than wiping, so an interrupted refresh never loses the cached copy. The DB lives at the platform data dir; override with `INDERES_FORUM_DB`. Beyond avoiding re-downloads, the cache is a queryable corpus — common fields land in real columns (`username`, `created_at`, `post_number`, `cooked`) for local analysis, and each post's full raw object is kept too, so `--json` stays faithful. Listings (search/latest/categories) are always live, never cached.
 >
 > **Why no login.** The forum is open to all, so authentication isn't required — and isn't currently possible anyway: the forum signs in via the same Keycloak but issues a Discourse session cookie rather than a reusable token, and its third-party User-API-Key feature is disabled. If the forum is ever switched to login-required, anonymous reads return 401/403 and the CLI reports that explicitly instead of failing cryptically. Point the forum base elsewhere with `INDERES_FORUM_URL`.
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,306 @@
+//! Local SQLite store for forum post history — a read-through cache that
+//! doubles as a queryable corpus.
+//!
+//! Forum post history is effectively immutable (old posts rarely change), so we
+//! cache it aggressively and only fetch the new tail on each run. The DB lives
+//! at the platform data dir (override with `INDERES_FORUM_DB`); posts are keyed
+//! by their stable Discourse `id` so upserts are idempotent.
+//!
+//! Beyond avoiding re-downloads, having posts in real tables (with
+//! `username`/`created_at`/`post_number` columns) makes downstream analysis —
+//! sentiment, per-user activity, posting-volume over time — a SQL query over
+//! local data instead of a re-fetch.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use directories::ProjectDirs;
+use rusqlite::{params, Connection, OptionalExtension};
+use serde_json::{json, Value};
+
+/// Handle to the on-disk (or in-memory, for tests) cache.
+pub struct Cache {
+    conn: Connection,
+}
+
+impl Cache {
+    /// Open the cache at the resolved platform path, creating it if needed.
+    pub fn open() -> Result<Self> {
+        let path = db_path()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        Self::open_at(&path)
+    }
+
+    pub fn open_at(path: &Path) -> Result<Self> {
+        let conn = Connection::open(path)
+            .with_context(|| format!("opening forum cache at {}", path.display()))?;
+        let cache = Self { conn };
+        cache.migrate()?;
+        Ok(cache)
+    }
+
+    #[cfg(test)]
+    pub fn open_in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory()?;
+        let cache = Self { conn };
+        cache.migrate()?;
+        Ok(cache)
+    }
+
+    fn migrate(&self) -> Result<()> {
+        self.conn
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS topics (
+                    id          INTEGER PRIMARY KEY,
+                    title       TEXT,
+                    posts_count INTEGER,
+                    last_page   INTEGER NOT NULL DEFAULT 0,
+                    synced_at   TEXT
+                 );
+                 CREATE TABLE IF NOT EXISTS posts (
+                    id          INTEGER PRIMARY KEY,
+                    topic_id    INTEGER NOT NULL,
+                    post_number INTEGER,
+                    username    TEXT,
+                    created_at  TEXT,
+                    updated_at  TEXT,
+                    cooked      TEXT,
+                    fetched_at  TEXT
+                 );
+                 CREATE INDEX IF NOT EXISTS idx_posts_topic
+                    ON posts(topic_id, post_number);",
+            )
+            .context("migrating forum cache schema")?;
+        Ok(())
+    }
+
+    /// Highest page already fetched for a topic (0 if the topic is uncached).
+    /// Used as the resume point for incremental fetching.
+    pub fn last_page(&self, topic_id: i64) -> Result<u32> {
+        let v: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT last_page FROM topics WHERE id = ?1",
+                [topic_id],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(v.unwrap_or(0).max(0) as u32)
+    }
+
+    /// Record topic metadata and advance the page watermark (never backwards).
+    pub fn set_topic_meta(
+        &self,
+        topic_id: i64,
+        title: Option<&str>,
+        posts_count: Option<i64>,
+        last_page: u32,
+    ) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO topics (id, title, posts_count, last_page, synced_at)
+             VALUES (?1, ?2, ?3, ?4, datetime('now'))
+             ON CONFLICT(id) DO UPDATE SET
+                title       = COALESCE(excluded.title, topics.title),
+                posts_count = COALESCE(excluded.posts_count, topics.posts_count),
+                last_page   = MAX(excluded.last_page, topics.last_page),
+                synced_at   = excluded.synced_at",
+            params![topic_id, title, posts_count, last_page as i64],
+        )?;
+        Ok(())
+    }
+
+    /// Upsert a batch of Discourse post objects. Returns how many had an `id`.
+    pub fn upsert_posts(&self, topic_id: i64, posts: &[Value]) -> Result<usize> {
+        let tx = self.conn.unchecked_transaction()?;
+        let mut count = 0;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO posts
+                    (id, topic_id, post_number, username, created_at, updated_at, cooked, fetched_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now'))
+                 ON CONFLICT(id) DO UPDATE SET
+                    post_number = excluded.post_number,
+                    username    = excluded.username,
+                    created_at  = excluded.created_at,
+                    updated_at  = excluded.updated_at,
+                    cooked      = excluded.cooked,
+                    fetched_at  = excluded.fetched_at",
+            )?;
+            for p in posts {
+                let Some(id) = p.get("id").and_then(Value::as_i64) else {
+                    continue;
+                };
+                stmt.execute(params![
+                    id,
+                    topic_id,
+                    p.get("post_number").and_then(Value::as_i64),
+                    p.get("username").and_then(Value::as_str),
+                    p.get("created_at").and_then(Value::as_str),
+                    p.get("updated_at").and_then(Value::as_str),
+                    p.get("cooked").and_then(Value::as_str),
+                ])?;
+                count += 1;
+            }
+        }
+        tx.commit()?;
+        Ok(count)
+    }
+
+    /// All cached posts for a topic, ordered by post number, shaped like the
+    /// Discourse post objects so the existing renderer can consume them.
+    pub fn get_posts(&self, topic_id: i64) -> Result<Vec<Value>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, post_number, username, created_at, updated_at, cooked
+             FROM posts WHERE topic_id = ?1 ORDER BY post_number",
+        )?;
+        let rows = stmt.query_map([topic_id], |r| {
+            Ok(json!({
+                "id": r.get::<_, i64>(0)?,
+                "post_number": r.get::<_, Option<i64>>(1)?,
+                "username": r.get::<_, Option<String>>(2)?,
+                "created_at": r.get::<_, Option<String>>(3)?,
+                "updated_at": r.get::<_, Option<String>>(4)?,
+                "cooked": r.get::<_, Option<String>>(5)?,
+            }))
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    pub fn topic_title(&self, topic_id: i64) -> Result<Option<String>> {
+        Ok(self
+            .conn
+            .query_row("SELECT title FROM topics WHERE id = ?1", [topic_id], |r| {
+                r.get::<_, Option<String>>(0)
+            })
+            .optional()?
+            .flatten())
+    }
+
+    pub fn post_count(&self, topic_id: i64) -> Result<i64> {
+        Ok(self.conn.query_row(
+            "SELECT COUNT(*) FROM posts WHERE topic_id = ?1",
+            [topic_id],
+            |r| r.get(0),
+        )?)
+    }
+
+    /// Drop everything cached for a topic (used by `--refresh`).
+    pub fn clear_topic(&self, topic_id: i64) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM posts WHERE topic_id = ?1", [topic_id])?;
+        self.conn
+            .execute("DELETE FROM topics WHERE id = ?1", [topic_id])?;
+        Ok(())
+    }
+}
+
+/// Resolve the cache DB path: `INDERES_FORUM_DB` if set, else the platform
+/// data dir.
+pub fn db_path() -> Result<PathBuf> {
+    if let Ok(explicit) = std::env::var("INDERES_FORUM_DB") {
+        if !explicit.is_empty() {
+            return Ok(PathBuf::from(explicit));
+        }
+    }
+    let dirs = ProjectDirs::from("com", "inderes", "inderes-cli")
+        .context("could not determine platform data directory")?;
+    Ok(dirs.data_dir().join("forum-cache.db"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn post(id: i64, n: i64, user: &str, cooked: &str) -> Value {
+        json!({
+            "id": id, "post_number": n, "username": user,
+            "created_at": "2026-01-01", "cooked": cooked
+        })
+    }
+
+    #[test]
+    fn upsert_then_get_returns_posts_in_post_number_order() {
+        let c = Cache::open_in_memory().unwrap();
+        c.upsert_posts(
+            7,
+            &[post(20, 2, "bob", "second"), post(10, 1, "alice", "first")],
+        )
+        .unwrap();
+        let got = c.get_posts(7).unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0]["username"], "alice"); // post_number 1 first
+        assert_eq!(got[1]["username"], "bob");
+        assert_eq!(got[0]["cooked"], "first");
+    }
+
+    #[test]
+    fn upsert_is_idempotent_and_updates_on_conflict() {
+        let c = Cache::open_in_memory().unwrap();
+        c.upsert_posts(7, &[post(10, 1, "alice", "original")])
+            .unwrap();
+        let n = c
+            .upsert_posts(7, &[post(10, 1, "alice", "edited")])
+            .unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(c.post_count(7).unwrap(), 1); // still one row
+        assert_eq!(c.get_posts(7).unwrap()[0]["cooked"], "edited"); // updated
+    }
+
+    #[test]
+    fn upsert_skips_posts_without_id() {
+        let c = Cache::open_in_memory().unwrap();
+        let n = c
+            .upsert_posts(7, &[json!({"post_number": 1, "cooked": "no id"})])
+            .unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(c.post_count(7).unwrap(), 0);
+    }
+
+    #[test]
+    fn last_page_defaults_to_zero_then_tracks_watermark() {
+        let c = Cache::open_in_memory().unwrap();
+        assert_eq!(c.last_page(7).unwrap(), 0);
+        c.set_topic_meta(7, Some("Title"), Some(40), 2).unwrap();
+        assert_eq!(c.last_page(7).unwrap(), 2);
+        // Watermark never moves backwards.
+        c.set_topic_meta(7, None, None, 1).unwrap();
+        assert_eq!(c.last_page(7).unwrap(), 2);
+        assert_eq!(c.topic_title(7).unwrap().as_deref(), Some("Title"));
+    }
+
+    #[test]
+    fn clear_topic_removes_posts_and_meta() {
+        let c = Cache::open_in_memory().unwrap();
+        c.upsert_posts(7, &[post(10, 1, "alice", "x")]).unwrap();
+        c.set_topic_meta(7, Some("T"), Some(1), 1).unwrap();
+        c.clear_topic(7).unwrap();
+        assert_eq!(c.post_count(7).unwrap(), 0);
+        assert_eq!(c.last_page(7).unwrap(), 0);
+        assert_eq!(c.topic_title(7).unwrap(), None);
+    }
+
+    #[test]
+    fn posts_are_scoped_per_topic() {
+        let c = Cache::open_in_memory().unwrap();
+        c.upsert_posts(7, &[post(10, 1, "a", "x")]).unwrap();
+        c.upsert_posts(8, &[post(11, 1, "b", "y")]).unwrap();
+        assert_eq!(c.post_count(7).unwrap(), 1);
+        assert_eq!(c.post_count(8).unwrap(), 1);
+        assert_eq!(c.get_posts(8).unwrap()[0]["username"], "b");
+    }
+
+    #[test]
+    fn db_path_honors_env_override() {
+        // SAFETY: single-threaded test mutating a process-wide var, restored after.
+        unsafe { std::env::set_var("INDERES_FORUM_DB", "/tmp/inderes-test.db") };
+        assert_eq!(db_path().unwrap(), PathBuf::from("/tmp/inderes-test.db"));
+        unsafe { std::env::remove_var("INDERES_FORUM_DB") };
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -92,7 +92,10 @@ impl Cache {
         Ok(v.unwrap_or(0).max(0) as u32)
     }
 
-    /// Record topic metadata and advance the page watermark (never backwards).
+    /// Record topic metadata and set the page watermark to the last page
+    /// fetched. The walk calls this with monotonically increasing page numbers,
+    /// so the final call stores the true high-water mark — and a `--refresh`
+    /// (or shrink re-walk) that ends on a lower page correctly lowers it.
     pub fn set_topic_meta(
         &self,
         topic_id: i64,
@@ -106,7 +109,7 @@ impl Cache {
              ON CONFLICT(id) DO UPDATE SET
                 title       = COALESCE(excluded.title, topics.title),
                 posts_count = COALESCE(excluded.posts_count, topics.posts_count),
-                last_page   = MAX(excluded.last_page, topics.last_page),
+                last_page   = excluded.last_page,
                 synced_at   = excluded.synced_at",
             params![topic_id, title, posts_count, last_page as i64],
         )?;
@@ -274,9 +277,10 @@ mod tests {
         assert_eq!(c.last_page(7).unwrap(), 0);
         c.set_topic_meta(7, Some("Title"), Some(40), 2).unwrap();
         assert_eq!(c.last_page(7).unwrap(), 2);
-        // Watermark never moves backwards.
+        // The watermark is absolute (a refresh/shrink re-walk that ends lower
+        // must lower it); title is preserved via COALESCE on a None update.
         c.set_topic_meta(7, None, None, 1).unwrap();
-        assert_eq!(c.last_page(7).unwrap(), 2);
+        assert_eq!(c.last_page(7).unwrap(), 1);
         assert_eq!(c.topic_title(7).unwrap().as_deref(), Some("Title"));
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -68,6 +68,7 @@ impl Cache {
                     created_at  TEXT,
                     updated_at  TEXT,
                     cooked      TEXT,
+                    raw         TEXT,
                     fetched_at  TEXT
                  );
                  CREATE INDEX IF NOT EXISTS idx_posts_topic
@@ -112,21 +113,25 @@ impl Cache {
         Ok(())
     }
 
-    /// Upsert a batch of Discourse post objects. Returns how many had an `id`.
+    /// Upsert a batch of Discourse post objects. The common fields are pulled
+    /// into typed columns for SQL analysis; the whole object is also stored in
+    /// `raw` so `--json` keeps full fidelity (reactions, post_url, …). Returns
+    /// how many had an `id`.
     pub fn upsert_posts(&self, topic_id: i64, posts: &[Value]) -> Result<usize> {
         let tx = self.conn.unchecked_transaction()?;
         let mut count = 0;
         {
             let mut stmt = tx.prepare(
                 "INSERT INTO posts
-                    (id, topic_id, post_number, username, created_at, updated_at, cooked, fetched_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now'))
+                    (id, topic_id, post_number, username, created_at, updated_at, cooked, raw, fetched_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, datetime('now'))
                  ON CONFLICT(id) DO UPDATE SET
                     post_number = excluded.post_number,
                     username    = excluded.username,
                     created_at  = excluded.created_at,
                     updated_at  = excluded.updated_at,
                     cooked      = excluded.cooked,
+                    raw         = excluded.raw,
                     fetched_at  = excluded.fetched_at",
             )?;
             for p in posts {
@@ -141,6 +146,7 @@ impl Cache {
                     p.get("created_at").and_then(Value::as_str),
                     p.get("updated_at").and_then(Value::as_str),
                     p.get("cooked").and_then(Value::as_str),
+                    serde_json::to_string(p)?,
                 ])?;
                 count += 1;
             }
@@ -149,21 +155,29 @@ impl Cache {
         Ok(count)
     }
 
-    /// All cached posts for a topic, ordered by post number, shaped like the
-    /// Discourse post objects so the existing renderer can consume them.
+    /// All cached posts for a topic, ordered by post number. Returns the full
+    /// original post objects (from `raw`) so `--json` stays faithful; falls
+    /// back to the typed columns if `raw` is somehow missing.
     pub fn get_posts(&self, topic_id: i64) -> Result<Vec<Value>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, post_number, username, created_at, updated_at, cooked
+            "SELECT raw, id, post_number, username, created_at, updated_at, cooked
              FROM posts WHERE topic_id = ?1 ORDER BY post_number",
         )?;
         let rows = stmt.query_map([topic_id], |r| {
+            let raw: Option<String> = r.get(0)?;
+            if let Some(v) = raw
+                .as_deref()
+                .and_then(|s| serde_json::from_str::<Value>(s).ok())
+            {
+                return Ok(v);
+            }
             Ok(json!({
-                "id": r.get::<_, i64>(0)?,
-                "post_number": r.get::<_, Option<i64>>(1)?,
-                "username": r.get::<_, Option<String>>(2)?,
-                "created_at": r.get::<_, Option<String>>(3)?,
-                "updated_at": r.get::<_, Option<String>>(4)?,
-                "cooked": r.get::<_, Option<String>>(5)?,
+                "id": r.get::<_, i64>(1)?,
+                "post_number": r.get::<_, Option<i64>>(2)?,
+                "username": r.get::<_, Option<String>>(3)?,
+                "created_at": r.get::<_, Option<String>>(4)?,
+                "updated_at": r.get::<_, Option<String>>(5)?,
+                "cooked": r.get::<_, Option<String>>(6)?,
             }))
         })?;
         let mut out = Vec::new();
@@ -189,15 +203,6 @@ impl Cache {
             [topic_id],
             |r| r.get(0),
         )?)
-    }
-
-    /// Drop everything cached for a topic (used by `--refresh`).
-    pub fn clear_topic(&self, topic_id: i64) -> Result<()> {
-        self.conn
-            .execute("DELETE FROM posts WHERE topic_id = ?1", [topic_id])?;
-        self.conn
-            .execute("DELETE FROM topics WHERE id = ?1", [topic_id])?;
-        Ok(())
     }
 }
 
@@ -276,14 +281,18 @@ mod tests {
     }
 
     #[test]
-    fn clear_topic_removes_posts_and_meta() {
+    fn get_posts_preserves_full_raw_object() {
+        // Fields beyond the typed columns (e.g. reactions) must survive a
+        // round-trip so `--json` stays faithful.
         let c = Cache::open_in_memory().unwrap();
-        c.upsert_posts(7, &[post(10, 1, "alice", "x")]).unwrap();
-        c.set_topic_meta(7, Some("T"), Some(1), 1).unwrap();
-        c.clear_topic(7).unwrap();
-        assert_eq!(c.post_count(7).unwrap(), 0);
-        assert_eq!(c.last_page(7).unwrap(), 0);
-        assert_eq!(c.topic_title(7).unwrap(), None);
+        let rich = json!({
+            "id": 10, "post_number": 1, "username": "alice",
+            "cooked": "hi", "post_url": "/t/7/1", "reactions": [{"id": "heart", "count": 3}]
+        });
+        c.upsert_posts(7, &[rich]).unwrap();
+        let got = c.get_posts(7).unwrap();
+        assert_eq!(got[0]["post_url"], "/t/7/1");
+        assert_eq!(got[0]["reactions"][0]["count"], 3);
     }
 
     #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -15,6 +15,7 @@ use clap_complete::Shell;
 use serde_json::{json, Map, Value};
 
 use crate::auth;
+use crate::cache;
 use crate::forum;
 use crate::mcp::McpClient;
 use crate::oauth::{self, IdpConfig};
@@ -246,9 +247,66 @@ pub async fn forum_search(ctx: &ToolCtx<'_>, query: &str) -> Result<()> {
     print_forum(&v, ctx.json_output, forum::render_search)
 }
 
-pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str, page: u32) -> Result<()> {
-    let v = forum_client(ctx).topic(id, page).await?;
-    print_forum(&v, ctx.json_output, forum::render_topic)
+/// Read a full topic through the local SQLite cache. On each call it resumes
+/// fetching from the last cached page (re-fetching it to catch newly-appended
+/// posts), walks until a page 404s, upserts as it goes, then renders the whole
+/// thread from the cache. A mid-walk error keeps progress and serves what's
+/// cached, so re-running resumes from the watermark.
+pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str, refresh: bool) -> Result<()> {
+    let topic_id: i64 = id
+        .parse()
+        .map_err(|_| anyhow!("invalid topic id {id:?}: expected a number"))?;
+    let cache = cache::Cache::open()?;
+    if refresh {
+        cache.clear_topic(topic_id)?;
+    }
+    let client = forum_client(ctx);
+
+    let mut page = cache.last_page(topic_id)?.max(1);
+    loop {
+        let v = match client.topic_page(id, page).await {
+            Ok(Some(v)) => v,
+            Ok(None) => break, // past the end of the thread
+            Err(e) => {
+                if cache.post_count(topic_id)? > 0 {
+                    eprintln!(
+                        "warning: forum fetch stopped at page {page} ({e:#}); \
+                         serving cached posts — re-run to resume."
+                    );
+                    break;
+                }
+                return Err(e);
+            }
+        };
+        let posts = v
+            .get("post_stream")
+            .and_then(|s| s.get("posts"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        if posts.is_empty() {
+            break;
+        }
+        cache.upsert_posts(topic_id, &posts)?;
+        cache.set_topic_meta(
+            topic_id,
+            v.get("title").and_then(Value::as_str),
+            v.get("posts_count").and_then(Value::as_i64),
+            page,
+        )?;
+        page += 1;
+    }
+
+    if cache.post_count(topic_id)? == 0 {
+        bail!("forum topic {id} not found or has no posts");
+    }
+
+    let envelope = json!({
+        "id": topic_id,
+        "title": cache.topic_title(topic_id)?.unwrap_or_default(),
+        "post_stream": { "posts": cache.get_posts(topic_id)? },
+    });
+    print_forum(&envelope, ctx.json_output, forum::render_topic)
 }
 
 pub async fn forum_latest(ctx: &ToolCtx<'_>) -> Result<()> {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -263,43 +263,27 @@ pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str, refresh: bool) -> Result<(
     let cache = cache::Cache::open()?;
     let client = forum_client(ctx);
 
-    let mut page = if refresh {
+    let start = if refresh {
         1
     } else {
         cache.last_page(topic_id)?.max(1)
     };
-    loop {
-        let v = match client.topic_page(id, page).await {
-            Ok(Some(v)) => v,
-            Ok(None) => break, // past the end of the thread
-            Err(e) => {
-                if cache.post_count(topic_id)? > 0 {
-                    eprintln!(
-                        "warning: forum fetch stopped at page {page} ({e:#}); \
-                         serving cached posts — re-run to resume."
-                    );
-                    break;
-                }
-                return Err(e);
-            }
-        };
-        let posts = v
-            .get("post_stream")
-            .and_then(|s| s.get("posts"))
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-        if posts.is_empty() {
-            break;
+    let (mut fetched_any, interrupted) =
+        walk_topic_pages(&client, &cache, id, topic_id, start).await?;
+
+    // A resumed walk (start > 1) that 404s immediately without fetching and
+    // without erroring is ambiguous: either the thread shrank below the cached
+    // watermark, or the topic was deleted / made private. Re-verify from page 1
+    // — that re-walks a shrunk thread (lowering the watermark) or confirms the
+    // topic is gone (so we don't silently pass off stale cache as fresh).
+    if !fetched_any && !interrupted && start > 1 {
+        (fetched_any, _) = walk_topic_pages(&client, &cache, id, topic_id, 1).await?;
+        if !fetched_any && cache.post_count(topic_id)? > 0 {
+            eprintln!(
+                "warning: forum topic {id} returned 404 (deleted or made private); \
+                 serving the cached copy."
+            );
         }
-        cache.upsert_posts(topic_id, &posts)?;
-        cache.set_topic_meta(
-            topic_id,
-            v.get("title").and_then(Value::as_str),
-            v.get("posts_count").and_then(Value::as_i64),
-            page,
-        )?;
-        page += 1;
     }
 
     if cache.post_count(topic_id)? == 0 {
@@ -312,6 +296,56 @@ pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str, refresh: bool) -> Result<(
         "post_stream": { "posts": cache.get_posts(topic_id)? },
     });
     print_forum(&envelope, ctx.json_output, forum::render_topic)
+}
+
+/// Walk a topic's pages from `start` until a page 404s (end of thread),
+/// upserting each page into the cache. Returns `(fetched_any, interrupted)`:
+/// `fetched_any` is whether any page yielded posts, `interrupted` is whether a
+/// transient error (rate limit / network) stopped the walk with cached posts
+/// still available to serve.
+async fn walk_topic_pages(
+    client: &forum::ForumClient<'_>,
+    cache: &cache::Cache,
+    id: &str,
+    topic_id: i64,
+    start: u32,
+) -> Result<(bool, bool)> {
+    let mut page = start;
+    let mut fetched_any = false;
+    loop {
+        let v = match client.topic_page(id, page).await {
+            Ok(Some(v)) => v,
+            Ok(None) => return Ok((fetched_any, false)), // past the end
+            Err(e) => {
+                if cache.post_count(topic_id)? > 0 {
+                    eprintln!(
+                        "warning: forum fetch stopped at page {page} ({e:#}); \
+                         serving cached posts — re-run to resume."
+                    );
+                    return Ok((fetched_any, true));
+                }
+                return Err(e);
+            }
+        };
+        let posts = v
+            .get("post_stream")
+            .and_then(|s| s.get("posts"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        if posts.is_empty() {
+            return Ok((fetched_any, false));
+        }
+        cache.upsert_posts(topic_id, &posts)?;
+        cache.set_topic_meta(
+            topic_id,
+            v.get("title").and_then(Value::as_str),
+            v.get("posts_count").and_then(Value::as_i64),
+            page,
+        )?;
+        fetched_any = true;
+        page += 1;
+    }
 }
 
 pub async fn forum_latest(ctx: &ToolCtx<'_>) -> Result<()> {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -252,17 +252,22 @@ pub async fn forum_search(ctx: &ToolCtx<'_>, query: &str) -> Result<()> {
 /// posts), walks until a page 404s, upserts as it goes, then renders the whole
 /// thread from the cache. A mid-walk error keeps progress and serves what's
 /// cached, so re-running resumes from the watermark.
+///
+/// `--refresh` re-walks from page 1 (picking up edits to older posts). It
+/// upserts rather than wiping first, so a refresh interrupted by a rate limit
+/// or network error never destroys the previously-complete cached copy.
 pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str, refresh: bool) -> Result<()> {
     let topic_id: i64 = id
         .parse()
         .map_err(|_| anyhow!("invalid topic id {id:?}: expected a number"))?;
     let cache = cache::Cache::open()?;
-    if refresh {
-        cache.clear_topic(topic_id)?;
-    }
     let client = forum_client(ctx);
 
-    let mut page = cache.last_page(topic_id)?.max(1);
+    let mut page = if refresh {
+        1
+    } else {
+        cache.last_page(topic_id)?.max(1)
+    };
     loop {
         let v = match client.topic_page(id, page).await {
             Ok(Some(v)) => v,

--- a/src/forum.rs
+++ b/src/forum.rs
@@ -39,7 +39,18 @@ impl<'a> ForumClient<'a> {
         }
     }
 
+    /// GET a JSON endpoint, treating 404 as an error. Used by the listing
+    /// endpoints (search/latest/categories) where a 404 is genuinely wrong.
     async fn get_json(&self, path: &str, query: &[(&str, &str)]) -> Result<Value> {
+        self.get_json_opt(path, query)
+            .await?
+            .ok_or_else(|| anyhow!("forum request to {path} returned HTTP 404 Not Found"))
+    }
+
+    /// Like `get_json` but returns `Ok(None)` on 404. Topic paging relies on
+    /// this: an out-of-range `?page` 404s, and that is the normal end-of-thread
+    /// signal, not an error.
+    async fn get_json_opt(&self, path: &str, query: &[(&str, &str)]) -> Result<Option<Value>> {
         let url = format!("{}{}", self.base, path);
         let resp = self
             .http
@@ -50,6 +61,9 @@ impl<'a> ForumClient<'a> {
             .await
             .with_context(|| format!("GET {url}"))?;
         let status = resp.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
         // A 401/403 on an anonymous read is the signature of the forum being
         // switched to login-required (Discourse `login_required`). Diagnose it
         // explicitly rather than emitting a bare status. Name the actual base
@@ -74,7 +88,7 @@ impl<'a> ForumClient<'a> {
             bail!("forum request to {path} returned HTTP {status}");
         }
         let body = resp.text().await.unwrap_or_default();
-        serde_json::from_str(&body).map_err(|e| {
+        let value = serde_json::from_str(&body).map_err(|e| {
             // A 200 carrying HTML (CDN / maintenance / login interstitial) is the
             // common non-JSON case — say so instead of a bare parse error.
             if body.trim_start().starts_with('<') {
@@ -85,7 +99,8 @@ impl<'a> ForumClient<'a> {
             } else {
                 anyhow!("parsing forum JSON response from {path}: {e}")
             }
-        })
+        })?;
+        Ok(Some(value))
     }
 
     /// Full-text search across topics and posts (`/search.json?q=`).
@@ -93,10 +108,12 @@ impl<'a> ForumClient<'a> {
         self.get_json("/search.json", &[("q", query)]).await
     }
 
-    /// A single topic with its post stream (`/t/<id>.json`). `page` is 1-based;
-    /// Discourse returns ~20 posts per page, so pass 2, 3, … to walk a long
-    /// thread. Page 1 is sent without the query param so it matches the bare URL.
-    pub async fn topic(&self, id: &str, page: u32) -> Result<Value> {
+    /// Fetch one page of a topic's post stream (`/t/<id>.json`) for the
+    /// read-through cache. `page` is 1-based and ~20 posts per page; page 1
+    /// omits the query param so it matches the bare URL. `Ok(None)` means the
+    /// page is past the end (Discourse 404s out-of-range pages) — the normal
+    /// loop terminator.
+    pub async fn topic_page(&self, id: &str, page: u32) -> Result<Option<Value>> {
         // Topic ids are integers; reject anything else so a stray slug or path
         // segment fails clearly instead of producing a confusing request.
         if id.is_empty() || !id.bytes().all(|b| b.is_ascii_digit()) {
@@ -109,7 +126,7 @@ impl<'a> ForumClient<'a> {
         } else {
             Vec::new()
         };
-        self.get_json(&path, &query).await
+        self.get_json_opt(&path, &query).await
     }
 
     /// Latest active topics (`/latest.json`).
@@ -539,7 +556,11 @@ mod tests {
 
         let http = reqwest::Client::new();
         let client = ForumClient::new(&http, &server.uri());
-        let v = client.topic("123", 1).await.unwrap();
+        let v = client
+            .topic_page("123", 1)
+            .await
+            .unwrap()
+            .expect("page present");
         assert_eq!(v["id"], 123);
     }
 
@@ -561,24 +582,43 @@ mod tests {
 
         let http = reqwest::Client::new();
         let client = ForumClient::new(&http, &server.uri());
-        let v = client.topic("123", 2).await.unwrap();
+        let v = client
+            .topic_page("123", 2)
+            .await
+            .unwrap()
+            .expect("page present");
         assert_eq!(v["post_stream"]["posts"][0]["post_number"], 21);
     }
 
     #[tokio::test]
-    async fn non_success_status_is_an_error_without_body() {
+    async fn topic_page_404_signals_end_of_thread() {
+        // An out-of-range page 404s; that is the loop terminator, not an error.
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/t/404.json"))
-            .respond_with(ResponseTemplate::new(404).set_body_string("<html>big error page</html>"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("<html>nope</html>"))
             .mount(&server)
             .await;
 
         let http = reqwest::Client::new();
         let client = ForumClient::new(&http, &server.uri());
-        let err = client.topic("404", 1).await.unwrap_err();
+        assert!(client.topic_page("404", 1).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn server_error_is_an_error_without_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/latest.json"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("<html>big error page</html>"))
+            .mount(&server)
+            .await;
+
+        let http = reqwest::Client::new();
+        let client = ForumClient::new(&http, &server.uri());
+        let err = client.latest().await.unwrap_err();
         let msg = format!("{err:#}");
-        assert!(msg.contains("404"), "got: {msg}");
+        assert!(msg.contains("500"), "got: {msg}");
         // The HTML body must not leak into the error.
         assert!(!msg.contains("big error page"), "got: {msg}");
     }
@@ -588,7 +628,7 @@ mod tests {
         // No network needed — validation happens before the request.
         let http = reqwest::Client::new();
         let client = ForumClient::new(&http, "https://example.com");
-        let err = client.topic("../latest", 1).await.unwrap_err();
+        let err = client.topic_page("../latest", 1).await.unwrap_err();
         assert!(
             format!("{err:#}").contains("invalid topic id"),
             "got: {err:#}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 //! subcommands. Agents discover it through an OpenClaw skill.
 
 mod auth;
+mod cache;
 mod commands;
 mod forum;
 mod mcp;
@@ -213,14 +214,15 @@ enum ForumCmd {
         /// Free-text query.
         query: String,
     },
-    /// Show a topic and its posts by numeric topic ID.
+    /// Show a full topic. Read-through cache: fetches any new posts, then
+    /// serves the whole thread from the local SQLite store.
     Topic {
         /// Numeric topic ID (the number in a /t/<slug>/<id> URL).
         id: String,
-        /// Page of posts to fetch (~20 per page, 1-based). Discourse paginates
-        /// long threads; pass 2, 3, … to read past the first page.
-        #[arg(long, default_value_t = 1)]
-        page: u32,
+        /// Re-fetch the whole thread from page 1, replacing the cached copy
+        /// (picks up edited or deleted posts).
+        #[arg(long)]
+        refresh: bool,
     },
     /// List the latest active topics.
     Latest,
@@ -333,8 +335,8 @@ async fn run() -> Result<()> {
         }) => commands::documents_read(&ctx, &document_id, sections).await,
 
         Command::Forum(ForumCmd::Search { query }) => commands::forum_search(&ctx, &query).await,
-        Command::Forum(ForumCmd::Topic { id, page }) => {
-            commands::forum_topic(&ctx, &id, page).await
+        Command::Forum(ForumCmd::Topic { id, refresh }) => {
+            commands::forum_topic(&ctx, &id, refresh).await
         }
         Command::Forum(ForumCmd::Latest) => commands::forum_latest(&ctx).await,
         Command::Forum(ForumCmd::Categories) => commands::forum_categories(&ctx).await,

--- a/src/skill/hermes.md
+++ b/src/skill/hermes.md
@@ -52,7 +52,7 @@ Append `--json` on any subcommand to get raw JSON (easier to post-process).
 ```bash
 inderes forum search "Nokia"      # full-text search across topics and posts
 inderes forum topic 74            # full thread (read-through SQLite cache)
-inderes forum topic 74 --refresh  # re-fetch whole thread, replacing the cache
+inderes forum topic 74 --refresh  # re-fetch from page 1, updating edits
 inderes forum latest              # latest active topics
 inderes forum categories          # category list
 ```

--- a/src/skill/hermes.md
+++ b/src/skill/hermes.md
@@ -50,13 +50,14 @@ Append `--json` on any subcommand to get raw JSON (easier to post-process).
 `inderes forum` reads the public Inderes forum (forum.inderes.com) directly — **no `inderes login` required**; it sends no credentials. Use it for community/retail sentiment and discussion, as distinct from analyst research.
 
 ```bash
-inderes forum search "Nokia"   # full-text search across topics and posts
-inderes forum topic 74         # a topic's posts (page 1; --page N for more)
-inderes forum latest           # latest active topics
-inderes forum categories       # category list
+inderes forum search "Nokia"      # full-text search across topics and posts
+inderes forum topic 74            # full thread (read-through SQLite cache)
+inderes forum topic 74 --refresh  # re-fetch whole thread, replacing the cache
+inderes forum latest              # latest active topics
+inderes forum categories          # category list
 ```
 
-Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns ~20 posts per page; pass `--page N` (1-based) to walk longer threads. This is separate from the authenticated MCP tool `inderes call search-forum-topics`.
+Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`.
 
 ## Procedure
 

--- a/src/skill/openclaw.md
+++ b/src/skill/openclaw.md
@@ -50,7 +50,7 @@ Pass `--json` to any of the above to get raw JSON (useful when you need to extra
 ```bash
 inderes forum search "Nokia"      # full-text search across topics and posts
 inderes forum topic 74            # full thread (read-through SQLite cache)
-inderes forum topic 74 --refresh  # re-fetch whole thread, replacing the cache
+inderes forum topic 74 --refresh  # re-fetch from page 1, updating edits
 inderes forum latest              # latest active topics
 inderes forum categories          # category list
 ```

--- a/src/skill/openclaw.md
+++ b/src/skill/openclaw.md
@@ -48,13 +48,14 @@ Pass `--json` to any of the above to get raw JSON (useful when you need to extra
 `inderes forum` reads the public Inderes forum (forum.inderes.com) directly — **no `inderes login` required**; it sends no credentials. Use it for community/retail sentiment and discussion, as distinct from analyst research.
 
 ```bash
-inderes forum search "Nokia"   # full-text search across topics and posts
-inderes forum topic 74         # a topic's posts (page 1; --page N for more)
-inderes forum latest           # latest active topics
-inderes forum categories       # category list
+inderes forum search "Nokia"      # full-text search across topics and posts
+inderes forum topic 74            # full thread (read-through SQLite cache)
+inderes forum topic 74 --refresh  # re-fetch whole thread, replacing the cache
+inderes forum latest              # latest active topics
+inderes forum categories          # category list
 ```
 
-Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns ~20 posts per page; pass `--page N` (1-based) to walk longer threads. This is separate from the authenticated MCP tool `inderes call search-forum-topics`.
+Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`.
 
 ## Escape hatch: all 16 tools
 

--- a/src/skill/ptrclaw.md
+++ b/src/skill/ptrclaw.md
@@ -47,7 +47,7 @@ Append `--json` on any subcommand to get raw JSON (easier to post-process).
 ```bash
 inderes forum search "Nokia"      # full-text search across topics and posts
 inderes forum topic 74            # full thread (read-through SQLite cache)
-inderes forum topic 74 --refresh  # re-fetch whole thread, replacing the cache
+inderes forum topic 74 --refresh  # re-fetch from page 1, updating edits
 inderes forum latest              # latest active topics
 inderes forum categories          # category list
 ```

--- a/src/skill/ptrclaw.md
+++ b/src/skill/ptrclaw.md
@@ -45,13 +45,14 @@ Append `--json` on any subcommand to get raw JSON (easier to post-process).
 `inderes forum` reads the public Inderes forum (forum.inderes.com) directly — **no `inderes login` required**; it sends no credentials. Use it for community/retail sentiment and discussion, as distinct from analyst research.
 
 ```bash
-inderes forum search "Nokia"   # full-text search across topics and posts
-inderes forum topic 74         # a topic's posts (page 1; --page N for more)
-inderes forum latest           # latest active topics
-inderes forum categories       # category list
+inderes forum search "Nokia"      # full-text search across topics and posts
+inderes forum topic 74            # full thread (read-through SQLite cache)
+inderes forum topic 74 --refresh  # re-fetch whole thread, replacing the cache
+inderes forum latest              # latest active topics
+inderes forum categories          # category list
 ```
 
-Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns ~20 posts per page; pass `--page N` (1-based) to walk longer threads. This is separate from the authenticated MCP tool `inderes call search-forum-topics`.
+Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`.
 
 ## Procedure
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -27,6 +27,7 @@ fn isolated() -> (Command, TempDir) {
     cmd.env_remove("INDERES_IDP_USERINFO_URL");
     cmd.env_remove("INDERES_IDP_CLIENT_ID");
     cmd.env_remove("INDERES_FORUM_URL");
+    cmd.env_remove("INDERES_FORUM_DB");
     (cmd, tmp)
 }
 


### PR DESCRIPTION
## What

Makes `inderes forum topic <id>` a transparent **read-through cache** backed by local SQLite.

Each call resumes fetching from the last cached page, walks `?page` until a 404 (the end-of-thread signal), upserts posts keyed by their stable Discourse `id`, then serves the **whole** thread from disk. So:

- A long thread is downloaded only once; re-reads are instant.
- The first call on a huge thread walks every page, but it's **resumable** — a mid-walk rate-limit/network error keeps progress and serves what's cached, so re-running continues from the watermark.
- `--refresh` re-walks from page 1 to pick up edits to older posts. It upserts rather than wiping, so an interrupted refresh never destroys a complete cached copy.

This **replaces the stopgap `--page N` flag** — manual paging is obsolete with an incremental cache.

## Why

The goal is a local corpus for sentiment analysis (and other queries) over forum posts, without re-pulling thousands of messages each time. Posts land in real columns (`username`, `created_at`, `post_number`, `cooked`) for SQL analysis, and each post's full raw object is also stored so `--json` stays faithful.

## Notes

- New dependency: `rusqlite` (bundled SQLite). Compiles cleanly on all dev targets. **Not included here:** a `release.yml` tweak (`CC_aarch64_unknown_linux_gnu`) for the aarch64-linux cross build — my token lacks `workflow` scope. It's belt-and-suspenders (the `cc` crate already defaults to `aarch64-linux-gnu-gcc` for that target); apply it only if a future aarch64 release build fails on the SQLite C compile.
- DB path overridable via `INDERES_FORUM_DB`. Listings (search/latest/categories) stay live, never cached.
- `forum topic --json` returns `{id, title, post_stream: {posts: [<full post objects>]}}` — a cache-backed envelope; post objects are full-fidelity, the topic wrapper is minimal by design.

## Review

Ran the local `codex review` before opening; it raised two [P2] findings (destructive `--refresh`, `--json` field loss). Both fixed in the third commit and verified live.

## Testing

- `src/cache.rs` unit tests (upsert/idempotency/ordering/watermark/raw-fidelity/scoping) + adjusted `forum.rs` tests (404 → end-of-thread).
- `cargo fmt`, `clippy --all-targets -D warnings`, `cargo test --all-targets` (145 tests), markdownlint — all clean.
- Live-tested: 7-page topic → 127 posts cached then served from disk; warm re-read; `--refresh` non-destructive; raw fields preserved in `--json`.
