### PR TITLE
feat(upgrade): refresh installed skills after upgrading

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ inderes upgrade --force        # re-install even if already on latest
 
 The CLI queries GitHub for the latest tag, compares to the running version, and (if newer or `--force`) shells out to the same `install.sh` / `install.ps1` you'd `curl | bash`. The new binary lands in the same directory the running binary was launched from, so an upgrade preserves the install location regardless of where you originally put it.
 
+After a successful upgrade, any skill files already installed at their default paths (`~/.<host>/skills/inderes/SKILL.md`) are **automatically refreshed** — the new binary rewrites them — so an agent's on-disk guidance stays in sync with the upgraded CLI's capabilities. (A skill installed to a custom `--dest` isn't tracked; re-run `install-skill` there yourself.)
+
 `inderes upgrade --check-only` is safe to run from cron or an agent.
 
 ## Uninstall

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ inderes install-skill hermes     # -> ~/.hermes/skills/inderes/SKILL.md
 inderes install-skill ptrclaw    # -> ~/.ptrclaw/skills/inderes/SKILL.md
 ```
 
-Pass `--force` to overwrite an existing skill, `--dest <path>` to write somewhere else. The skill content is shipped inside the binary, so reinstalling after a CLI upgrade always gives the agent up-to-date guidance.
+Pass `--force` to overwrite an existing skill, `--dest <path>` to write somewhere else. The skill content is shipped inside the binary, and `inderes upgrade` automatically refreshes skills installed at their default paths — so an agent's guidance stays up to date without a manual reinstall (only re-run `install-skill` for custom `--dest` locations).
 
 All three skills teach the model to shell out to `inderes <subcommand>` via the host's terminal/bash/shell tool — no MCP server registration, no tool-schema bloat.
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -492,9 +492,44 @@ pub async fn upgrade(http: &reqwest::Client, check_only: bool, force: bool) -> R
     if !status.success() {
         bail!("install script exited with {status}");
     }
+
+    // The new binary is now in place. Have *it* rewrite any installed skill
+    // files so an agent's on-disk SKILL.md matches the upgraded capabilities —
+    // this process is still the old binary and can't emit the new skill text.
+    refresh_installed_skills(&exe).await;
+
     println!();
     println!("Done. Verify with: inderes --version");
     Ok(())
+}
+
+/// After an upgrade, ask the freshly-installed binary to rewrite every skill
+/// that's currently present at its default path, so an agent reads guidance
+/// matching the new binary. Best-effort, default paths only (same scope as
+/// `uninstall --remove-skills`); a custom `--dest` install isn't tracked.
+async fn refresh_installed_skills(new_exe: &std::path::Path) {
+    use tokio::process::Command;
+    let mut refreshed_any = false;
+    for host in skill::Host::ALL {
+        let path = host.default_install_path();
+        if !path.exists() {
+            continue;
+        }
+        refreshed_any = true;
+        let name = host.cli_name();
+        match Command::new(new_exe)
+            .args(["install-skill", name, "--force"])
+            .status()
+            .await
+        {
+            Ok(s) if s.success() => println!("✓ Refreshed {name} skill at {}", path.display()),
+            Ok(s) => eprintln!("warning: refreshing {name} skill exited with {s}"),
+            Err(e) => eprintln!("warning: could not refresh {name} skill: {e:#}"),
+        }
+    }
+    if refreshed_any {
+        println!();
+    }
 }
 
 #[cfg(unix)]
@@ -555,15 +590,11 @@ async fn run_install_script(
 /// Lists the on-disk skill paths for every supported host whose skill file
 /// is currently present. Pure helper for testability.
 pub(crate) fn installed_skill_paths() -> Vec<PathBuf> {
-    [
-        skill::Host::Openclaw,
-        skill::Host::Hermes,
-        skill::Host::Ptrclaw,
-    ]
-    .into_iter()
-    .map(|h| h.default_install_path())
-    .filter(|p| p.exists())
-    .collect()
+    skill::Host::ALL
+        .into_iter()
+        .map(|h| h.default_install_path())
+        .filter(|p| p.exists())
+        .collect()
 }
 
 pub fn uninstall(yes: bool, remove_skills: bool) -> Result<()> {

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -21,6 +21,20 @@ pub enum Host {
 }
 
 impl Host {
+    /// Every supported host, for iteration.
+    pub const ALL: [Host; 3] = [Host::Openclaw, Host::Hermes, Host::Ptrclaw];
+
+    /// The value accepted by `install-skill <host>` on the CLI. Kept in sync
+    /// with clap's `ValueEnum` names (see the `cli_name_matches_clap` test) so
+    /// it's safe to pass back to a child `inderes install-skill` invocation.
+    pub fn cli_name(self) -> &'static str {
+        match self {
+            Host::Openclaw => "openclaw",
+            Host::Hermes => "hermes",
+            Host::Ptrclaw => "ptrclaw",
+        }
+    }
+
     /// The embedded SKILL.md body for this host.
     pub fn body(self) -> &'static str {
         match self {
@@ -104,5 +118,15 @@ mod tests {
     #[test]
     fn openclaw_skill_has_openclaw_metadata() {
         assert!(Host::Openclaw.body().contains("openclaw"));
+    }
+
+    #[test]
+    fn cli_name_matches_clap_value() {
+        // cli_name() is fed back to `install-skill <host>`, so it must equal the
+        // string clap accepts for each variant.
+        for h in Host::ALL {
+            let pv = h.to_possible_value().expect("variant is not skipped");
+            assert_eq!(h.cli_name(), pv.get_name(), "mismatch for {h:?}");
+        }
     }
 }


### PR DESCRIPTION
## What

`inderes upgrade` now **refreshes installed skill files** after replacing the binary.

Previously upgrade swapped only the binary, leaving each agent's on-disk `~/.<host>/skills/inderes/SKILL.md` — the file the agent actually reads — stale until the user manually re-ran `install-skill --force`. So an upgraded CLI could know about `forum` while the agent's skill still didn't.

Now, after a successful upgrade, every skill present at its default path is rewritten so agent guidance tracks the new binary's capabilities.

## How

The running `upgrade` process is the **old** binary, so its embedded skill text (`Host::body()`) is old — it can't emit the new content. Instead, once the install script has put the new binary in place, we invoke **that** binary: `<new-exe> install-skill <host> --force` for each host whose default skill path exists.

Best-effort, default paths only (same scope as `uninstall --remove-skills`); a custom `--dest` install isn't tracked and is noted in the README.

## Notes

- Adds `Host::ALL` (shared iteration, also used by `installed_skill_paths`) and `Host::cli_name` — verified against clap's `ValueEnum` names by a unit test, so the value passed to the child `install-skill` is always valid.

## Testing

- `cli_name_matches_clap_value` guards the host→arg mapping; `fmt` + `clippy -D warnings` + `cargo test --all-targets` (146 tests) + markdownlint all clean.
- Local `codex review` run pre-PR: no findings.
- The refresh path itself execs the freshly-installed binary, so it's exercised at real-upgrade time rather than in unit tests.
