### PR TITLE
feat(forum): query and db-path for analyzing the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ inderes --json forum topic 74 | jq '.post_stream.posts[].cooked'
 >
 > **Why no login.** The forum is open to all, so authentication isn't required — and isn't currently possible anyway: the forum signs in via the same Keycloak but issues a Discourse session cookie rather than a reusable token, and its third-party User-API-Key feature is disabled. If the forum is ever switched to login-required, anonymous reads return 401/403 and the CLI reports that explicitly instead of failing cryptically. Point the forum base elsewhere with `INDERES_FORUM_URL`.
 
+**Analyzing the cache.** Once topics are cached, query them with SQL straight from the CLI, or point your own tools at the database file:
+
+```bash
+inderes forum db-path                 # path to the SQLite file
+inderes forum query "SELECT username, COUNT(*) n FROM posts GROUP BY username ORDER BY n DESC LIMIT 10"
+inderes --json forum query "SELECT date(created_at) d, COUNT(*) c FROM posts GROUP BY d ORDER BY d"
+datasette "$(inderes forum db-path)"  # or duckdb / sqlite3 / pandas — it's a plain SQLite file
+```
+
+`forum query` opens the cache **read-only**, so a query can never modify it; table output by default, `--json` emits rows as an array of objects. The `posts` table has typed columns (`id`, `topic_id`, `post_number`, `username`, `created_at`, `cooked`, …) plus a `raw` column with each post's full JSON.
+
 ## Upgrade
 
 ```bash

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -214,7 +214,16 @@ impl Cache {
     /// a read-only connection (see `open_readonly`) so a query can never mutate
     /// the cache — a write statement errors with "readonly database".
     pub fn query(&self, sql: &str) -> Result<QueryResult> {
-        let mut stmt = self.conn.prepare(sql).context("preparing SQL query")?;
+        let trimmed = sql.trim();
+        if trimmed.is_empty() {
+            bail!("no SQL provided");
+        }
+        // `conn.prepare` compiles only the first statement and silently ignores
+        // the rest, so reject multi-statement input rather than drop it.
+        if !is_single_statement(trimmed) {
+            bail!("only a single SQL statement is supported");
+        }
+        let mut stmt = self.conn.prepare(trimmed).context("preparing SQL query")?;
         let columns: Vec<String> = stmt.column_names().iter().map(|s| s.to_string()).collect();
         let n = columns.len();
         let rows = stmt
@@ -259,16 +268,34 @@ pub struct QueryResult {
 }
 
 /// Convert a dynamically-typed SQLite cell into JSON. Blobs become a short
-/// placeholder rather than dumping binary.
+/// placeholder rather than dumping binary (the cache has no blob columns; this
+/// only matters for contrived queries like `randomblob()`).
 fn sqlite_to_json(v: rusqlite::types::Value) -> Value {
     use rusqlite::types::Value as Sql;
     match v {
         Sql::Null => Value::Null,
         Sql::Integer(i) => Value::from(i),
-        Sql::Real(f) => Value::from(f),
+        // serde_json can't represent NaN/Infinity (Value::from returns Null for
+        // them), which would masquerade as a SQL NULL. Surface them as strings.
+        Sql::Real(f) if f.is_finite() => Value::from(f),
+        Sql::Real(f) => Value::String(f.to_string()),
         Sql::Text(s) => Value::String(s),
         Sql::Blob(b) => Value::String(format!("[blob {} bytes]", b.len())),
     }
+}
+
+/// True unless `sql` contains a `;` (outside a string literal) followed by more
+/// SQL — i.e. it's a single statement, optionally with a trailing semicolon.
+fn is_single_statement(sql: &str) -> bool {
+    let mut in_str = false;
+    for (i, c) in sql.char_indices() {
+        match c {
+            '\'' => in_str = !in_str,
+            ';' if !in_str => return sql[i + 1..].trim().is_empty(),
+            _ => {}
+        }
+    }
+    true
 }
 
 /// Resolve the cache DB path: `INDERES_FORUM_DB` if set, else the platform
@@ -408,6 +435,27 @@ mod tests {
                 || format!("{err:#}").to_lowercase().contains("read only"),
             "got: {err:#}"
         );
+    }
+
+    #[test]
+    fn query_rejects_empty_and_multi_statement() {
+        let c = Cache::open_in_memory().unwrap();
+        assert!(format!("{:#}", c.query("").unwrap_err()).contains("no SQL"));
+        assert!(format!("{:#}", c.query("   ").unwrap_err()).contains("no SQL"));
+        assert!(format!("{:#}", c.query("SELECT 1; SELECT 2").unwrap_err())
+            .contains("single SQL statement"));
+        // A trailing semicolon is fine, and a semicolon inside a string literal
+        // is not a statement separator.
+        assert!(c.query("SELECT 1;").is_ok());
+        assert!(c.query("SELECT 'a;b' AS s").is_ok());
+    }
+
+    #[test]
+    fn query_surfaces_non_finite_floats_as_strings() {
+        let c = Cache::open_in_memory().unwrap();
+        let r = c.query("SELECT 1e308 * 10 AS x").unwrap();
+        // Would be JSON null via Value::from(f64); we surface it as a string.
+        assert!(r.rows[0][0].is_string(), "got: {:?}", r.rows[0][0]);
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -14,12 +14,13 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use directories::ProjectDirs;
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use serde_json::{json, Value};
 
 /// Handle to the on-disk (or in-memory, for tests) cache.
+#[derive(Debug)]
 pub struct Cache {
     conn: Connection,
 }
@@ -40,6 +41,25 @@ impl Cache {
         let cache = Self { conn };
         cache.migrate()?;
         Ok(cache)
+    }
+
+    /// Open the cache **read-only** for querying. Errors if it doesn't exist
+    /// yet — there's nothing to analyze until a `forum topic` has populated it.
+    /// Read-only means an arbitrary user/agent query can't mutate the cache.
+    pub fn open_readonly() -> Result<Self> {
+        Self::open_readonly_at(&db_path()?)
+    }
+
+    pub fn open_readonly_at(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            bail!(
+                "no forum cache at {} yet — run `inderes forum topic <id>` first",
+                path.display()
+            );
+        }
+        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .with_context(|| format!("opening forum cache (read-only) at {}", path.display()))?;
+        Ok(Self { conn })
     }
 
     #[cfg(test)]
@@ -190,6 +210,27 @@ impl Cache {
         Ok(out)
     }
 
+    /// Run an arbitrary SQL query and return its columns and rows. Intended for
+    /// a read-only connection (see `open_readonly`) so a query can never mutate
+    /// the cache — a write statement errors with "readonly database".
+    pub fn query(&self, sql: &str) -> Result<QueryResult> {
+        let mut stmt = self.conn.prepare(sql).context("preparing SQL query")?;
+        let columns: Vec<String> = stmt.column_names().iter().map(|s| s.to_string()).collect();
+        let n = columns.len();
+        let rows = stmt
+            .query_map([], |row| {
+                let mut out = Vec::with_capacity(n);
+                for i in 0..n {
+                    out.push(sqlite_to_json(row.get::<_, rusqlite::types::Value>(i)?));
+                }
+                Ok(out)
+            })
+            .context("running SQL query")?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .context("reading query results")?;
+        Ok(QueryResult { columns, rows })
+    }
+
     pub fn topic_title(&self, topic_id: i64) -> Result<Option<String>> {
         Ok(self
             .conn
@@ -206,6 +247,27 @@ impl Cache {
             [topic_id],
             |r| r.get(0),
         )?)
+    }
+}
+
+/// Columns and rows returned by [`Cache::query`]; each row is one value per
+/// column, in `columns` order.
+#[derive(Debug)]
+pub struct QueryResult {
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<Value>>,
+}
+
+/// Convert a dynamically-typed SQLite cell into JSON. Blobs become a short
+/// placeholder rather than dumping binary.
+fn sqlite_to_json(v: rusqlite::types::Value) -> Value {
+    use rusqlite::types::Value as Sql;
+    match v {
+        Sql::Null => Value::Null,
+        Sql::Integer(i) => Value::from(i),
+        Sql::Real(f) => Value::from(f),
+        Sql::Text(s) => Value::String(s),
+        Sql::Blob(b) => Value::String(format!("[blob {} bytes]", b.len())),
     }
 }
 
@@ -307,6 +369,55 @@ mod tests {
         assert_eq!(c.post_count(7).unwrap(), 1);
         assert_eq!(c.post_count(8).unwrap(), 1);
         assert_eq!(c.get_posts(8).unwrap()[0]["username"], "b");
+    }
+
+    #[test]
+    fn query_returns_columns_and_rows() {
+        let c = Cache::open_in_memory().unwrap();
+        c.upsert_posts(7, &[post(10, 1, "alice", "x"), post(11, 2, "alice", "y")])
+            .unwrap();
+        c.upsert_posts(7, &[post(12, 3, "bob", "z")]).unwrap();
+        let r = c
+            .query("SELECT username, COUNT(*) n FROM posts GROUP BY username ORDER BY n DESC")
+            .unwrap();
+        assert_eq!(r.columns, vec!["username", "n"]);
+        assert_eq!(r.rows.len(), 2);
+        assert_eq!(r.rows[0][0], serde_json::json!("alice"));
+        assert_eq!(r.rows[0][1], serde_json::json!(2)); // integer mapped to JSON number
+    }
+
+    #[test]
+    fn readonly_connection_rejects_writes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("forum.db");
+        {
+            let c = Cache::open_at(&path).unwrap();
+            c.upsert_posts(7, &[post(10, 1, "alice", "x")]).unwrap();
+        }
+        let ro = Cache::open_readonly_at(&path).unwrap();
+        // Reads work...
+        assert_eq!(
+            ro.query("SELECT COUNT(*) FROM posts").unwrap().rows[0][0],
+            serde_json::json!(1)
+        );
+        // ...writes are refused by the read-only connection.
+        let err = ro.query("DELETE FROM posts").unwrap_err();
+        assert!(
+            format!("{err:#}").to_lowercase().contains("readonly")
+                || format!("{err:#}").to_lowercase().contains("read-only")
+                || format!("{err:#}").to_lowercase().contains("read only"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn open_readonly_errors_when_cache_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let err = Cache::open_readonly_at(&dir.path().join("nope.db")).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("no forum cache"),
+            "got: {err:#}"
+        );
     }
 
     #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -369,6 +369,95 @@ fn print_forum(v: &Value, as_json: bool, render: fn(&Value) -> String) -> Result
     Ok(())
 }
 
+/// Print the path to the local forum cache DB (so you can point sqlite3 /
+/// datasette / duckdb / pandas at it).
+pub fn forum_db_path() -> Result<()> {
+    println!("{}", cache::db_path()?.display());
+    Ok(())
+}
+
+/// Run a read-only SQL query against the local forum cache. Table output by
+/// default, array-of-objects under `--json`.
+pub fn forum_query(ctx: &ToolCtx<'_>, sql: &str) -> Result<()> {
+    let cache = cache::Cache::open_readonly()?;
+    let result = cache.query(sql)?;
+    if ctx.json_output {
+        let arr: Vec<Value> = result
+            .rows
+            .iter()
+            .map(|row| {
+                let mut obj = Map::new();
+                for (col, val) in result.columns.iter().zip(row) {
+                    obj.insert(col.clone(), val.clone());
+                }
+                Value::Object(obj)
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&Value::Array(arr))?);
+    } else {
+        print!("{}", render_query_table(&result));
+    }
+    Ok(())
+}
+
+/// Render query results as a simple column-aligned text table.
+fn render_query_table(r: &cache::QueryResult) -> String {
+    if r.columns.is_empty() {
+        return "(no columns)\n".to_string();
+    }
+    let cells: Vec<Vec<String>> = r
+        .rows
+        .iter()
+        .map(|row| row.iter().map(cell_to_string).collect())
+        .collect();
+    let mut widths: Vec<usize> = r.columns.iter().map(|c| c.chars().count()).collect();
+    for row in &cells {
+        for (i, c) in row.iter().enumerate() {
+            if i < widths.len() {
+                widths[i] = widths[i].max(c.chars().count());
+            }
+        }
+    }
+    let pad = |s: &str, w: usize| format!("{s}{}", " ".repeat(w.saturating_sub(s.chars().count())));
+    let mut out = String::new();
+    let header: Vec<String> = r
+        .columns
+        .iter()
+        .enumerate()
+        .map(|(i, c)| pad(c, widths[i]))
+        .collect();
+    out.push_str(header.join("  ").trim_end());
+    out.push('\n');
+    out.push_str(
+        &widths
+            .iter()
+            .map(|w| "-".repeat(*w))
+            .collect::<Vec<_>>()
+            .join("  "),
+    );
+    out.push('\n');
+    for row in &cells {
+        let line: Vec<String> = row
+            .iter()
+            .enumerate()
+            .map(|(i, c)| pad(c, *widths.get(i).unwrap_or(&0)))
+            .collect();
+        out.push_str(line.join("  ").trim_end());
+        out.push('\n');
+    }
+    let n = r.rows.len();
+    out.push_str(&format!("({n} row{})\n", if n == 1 { "" } else { "s" }));
+    out
+}
+
+fn cell_to_string(v: &Value) -> String {
+    match v {
+        Value::Null => String::new(),
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
 // --- generic escape hatch --------------------------------------------------
 
 pub async fn call(
@@ -843,6 +932,35 @@ mod tests {
     fn build_args_empty_yields_empty_object() {
         let args = build_args(vec![], None).unwrap();
         assert_eq!(args, json!({}));
+    }
+
+    // --- render_query_table -----------------------------------------------
+
+    #[test]
+    fn render_query_table_aligns_and_counts_rows() {
+        let r = cache::QueryResult {
+            columns: vec!["username".into(), "n".into()],
+            rows: vec![
+                vec![json!("alice"), json!(2)],
+                vec![json!("bob"), json!(10)],
+            ],
+        };
+        let out = render_query_table(&r);
+        assert!(out.contains("username"));
+        assert!(out.contains("alice"));
+        assert!(out.contains("bob"));
+        assert!(out.contains("10"));
+        assert!(out.contains("(2 rows)"));
+    }
+
+    #[test]
+    fn render_query_table_handles_empty_and_null() {
+        let r = cache::QueryResult {
+            columns: vec!["a".into()],
+            rows: vec![vec![Value::Null]],
+        };
+        let out = render_query_table(&r);
+        assert!(out.contains("(1 row)"), "got: {out}");
     }
 
     // --- render_result / render_content_item ------------------------------

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -372,7 +372,11 @@ fn print_forum(v: &Value, as_json: bool, render: fn(&Value) -> String) -> Result
 /// Print the path to the local forum cache DB (so you can point sqlite3 /
 /// datasette / duckdb / pandas at it).
 pub fn forum_db_path() -> Result<()> {
-    println!("{}", cache::db_path()?.display());
+    let path = cache::db_path()?;
+    println!("{}", path.display());
+    if !path.exists() {
+        eprintln!("(no cache yet — run `inderes forum topic <id>` to create it)");
+    }
     Ok(())
 }
 
@@ -382,13 +386,22 @@ pub fn forum_query(ctx: &ToolCtx<'_>, sql: &str) -> Result<()> {
     let cache = cache::Cache::open_readonly()?;
     let result = cache.query(sql)?;
     if ctx.json_output {
-        let arr: Vec<Value> = result
-            .rows
-            .iter()
+        let cache::QueryResult { columns, rows } = result;
+        let arr: Vec<Value> = rows
+            .into_iter()
             .map(|row| {
                 let mut obj = Map::new();
-                for (col, val) in result.columns.iter().zip(row) {
-                    obj.insert(col.clone(), val.clone());
+                for (col, val) in columns.iter().zip(row) {
+                    // Duplicate column names (e.g. `SELECT a, b AS a`) would
+                    // collapse in a JSON object — suffix the repeats so no
+                    // column is silently dropped.
+                    let mut key = col.clone();
+                    let mut k = 2;
+                    while obj.contains_key(&key) {
+                        key = format!("{col}_{k}");
+                        k += 1;
+                    }
+                    obj.insert(key, val);
                 }
                 Value::Object(obj)
             })
@@ -396,6 +409,9 @@ pub fn forum_query(ctx: &ToolCtx<'_>, sql: &str) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&Value::Array(arr))?);
     } else {
         print!("{}", render_query_table(&result));
+        // Row count is metadata — keep it off stdout so the table pipes cleanly.
+        let n = result.rows.len();
+        eprintln!("({n} row{})", if n == 1 { "" } else { "s" });
     }
     Ok(())
 }
@@ -410,12 +426,12 @@ fn render_query_table(r: &cache::QueryResult) -> String {
         .iter()
         .map(|row| row.iter().map(cell_to_string).collect())
         .collect();
+    // Every row has exactly columns.len() cells (Cache::query guarantees it),
+    // so direct indexing is safe.
     let mut widths: Vec<usize> = r.columns.iter().map(|c| c.chars().count()).collect();
     for row in &cells {
         for (i, c) in row.iter().enumerate() {
-            if i < widths.len() {
-                widths[i] = widths[i].max(c.chars().count());
-            }
+            widths[i] = widths[i].max(c.chars().count());
         }
     }
     let pad = |s: &str, w: usize| format!("{s}{}", " ".repeat(w.saturating_sub(s.chars().count())));
@@ -440,13 +456,11 @@ fn render_query_table(r: &cache::QueryResult) -> String {
         let line: Vec<String> = row
             .iter()
             .enumerate()
-            .map(|(i, c)| pad(c, *widths.get(i).unwrap_or(&0)))
+            .map(|(i, c)| pad(c, widths[i]))
             .collect();
         out.push_str(line.join("  ").trim_end());
         out.push('\n');
     }
-    let n = r.rows.len();
-    out.push_str(&format!("({n} row{})\n", if n == 1 { "" } else { "s" }));
     out
 }
 
@@ -937,7 +951,7 @@ mod tests {
     // --- render_query_table -----------------------------------------------
 
     #[test]
-    fn render_query_table_aligns_and_counts_rows() {
+    fn render_query_table_aligns_columns() {
         let r = cache::QueryResult {
             columns: vec!["username".into(), "n".into()],
             rows: vec![
@@ -950,17 +964,18 @@ mod tests {
         assert!(out.contains("alice"));
         assert!(out.contains("bob"));
         assert!(out.contains("10"));
-        assert!(out.contains("(2 rows)"));
+        // The row count is emitted on stderr by forum_query, not in the table.
+        assert!(!out.contains("rows)"), "got: {out}");
     }
 
     #[test]
-    fn render_query_table_handles_empty_and_null() {
+    fn render_query_table_handles_null_cell() {
         let r = cache::QueryResult {
             columns: vec!["a".into()],
             rows: vec![vec![Value::Null]],
         };
         let out = render_query_table(&r);
-        assert!(out.contains("(1 row)"), "got: {out}");
+        assert!(out.starts_with("a\n"), "got: {out}"); // header present, null renders blank
     }
 
     // --- render_result / render_content_item ------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,6 +228,13 @@ enum ForumCmd {
     Latest,
     /// List forum categories.
     Categories,
+    /// Run a read-only SQL query against the local forum cache.
+    Query {
+        /// SQL to run (e.g. "SELECT username, COUNT(*) FROM posts GROUP BY username").
+        sql: String,
+    },
+    /// Print the path to the local forum cache database.
+    DbPath,
 }
 
 #[derive(Debug, Subcommand)]
@@ -340,6 +347,8 @@ async fn run() -> Result<()> {
         }
         Command::Forum(ForumCmd::Latest) => commands::forum_latest(&ctx).await,
         Command::Forum(ForumCmd::Categories) => commands::forum_categories(&ctx).await,
+        Command::Forum(ForumCmd::Query { sql }) => commands::forum_query(&ctx, &sql),
+        Command::Forum(ForumCmd::DbPath) => commands::forum_db_path(),
 
         Command::Call {
             tool,

--- a/src/skill/hermes.md
+++ b/src/skill/hermes.md
@@ -55,9 +55,11 @@ inderes forum topic 74            # full thread (read-through SQLite cache)
 inderes forum topic 74 --refresh  # re-fetch from page 1, updating edits
 inderes forum latest              # latest active topics
 inderes forum categories          # category list
+inderes forum query "<SQL>"       # read-only SQL over the cached posts
+inderes forum db-path             # path to the local SQLite cache
 ```
 
-Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`.
+Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`. Cached posts are queryable with `inderes forum query "<SQL>"` (read-only) — e.g. most active users on a stock, or posting volume over time.
 
 ## Procedure
 

--- a/src/skill/openclaw.md
+++ b/src/skill/openclaw.md
@@ -53,9 +53,11 @@ inderes forum topic 74            # full thread (read-through SQLite cache)
 inderes forum topic 74 --refresh  # re-fetch from page 1, updating edits
 inderes forum latest              # latest active topics
 inderes forum categories          # category list
+inderes forum query "<SQL>"       # read-only SQL over the cached posts
+inderes forum db-path             # path to the local SQLite cache
 ```
 
-Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`.
+Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`. Cached posts are queryable with `inderes forum query "<SQL>"` (read-only) — e.g. most active users on a stock, or posting volume over time.
 
 ## Escape hatch: all 16 tools
 

--- a/src/skill/ptrclaw.md
+++ b/src/skill/ptrclaw.md
@@ -50,9 +50,11 @@ inderes forum topic 74            # full thread (read-through SQLite cache)
 inderes forum topic 74 --refresh  # re-fetch from page 1, updating edits
 inderes forum latest              # latest active topics
 inderes forum categories          # category list
+inderes forum query "<SQL>"       # read-only SQL over the cached posts
+inderes forum db-path             # path to the local SQLite cache
 ```
 
-Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`.
+Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`. Cached posts are queryable with `inderes forum query "<SQL>"` (read-only) — e.g. most active users on a stock, or posting volume over time.
 
 ## Procedure
 


### PR DESCRIPTION
## What

Adds two read-only ways to analyze the cached forum corpus, so the SQLite data is actually usable without hunting for the file:

- `inderes forum query "<SQL>"` — runs SQL against the cache and prints a table (or `--json` as an array of objects).
- `inderes forum db-path` — prints the SQLite file path, so you can point `datasette` / `duckdb` / `sqlite3` / pandas at it.

## Safety

`query` opens the cache over a **read-only** SQLite connection (`OPEN_READONLY`), so an arbitrary query — even from an agent — can't mutate or corrupt the cache. A write statement returns "attempt to write a readonly database". Missing cache gives a clear "run `forum topic` first" error.

## Notes

- `cache.rs`: `open_readonly(_at)` + `query()` returning `QueryResult` (columns + rows, SQLite→JSON conversion); `Cache`/`QueryResult` derive `Debug`.
- `commands.rs`: command bodies + a small column-aligned table renderer.
- The `posts` table exposes typed columns for SQL plus a `raw` column with each post's full JSON.
- Documented in README and all three skills.

## Testing

- cache: `query` columns/rows, read-only rejects writes, missing-cache error.
- commands: table renderer alignment + row count.
- `fmt` + `clippy -D warnings` + `cargo test --all-targets` (151 tests) + markdownlint clean.
- Live-tested: populate → table query → `--json` query → `db-path` → write rejected → empty-cache error.

> Note: the local `codex review` couldn't run (workspace out of credits), so this relies on the GitHub Codex review plus local tests.
