### PR TITLE
feat(forum): clean-text column + agent analysis recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ inderes --json forum query "SELECT date(created_at) d, COUNT(*) c FROM posts GRO
 datasette "$(inderes forum db-path)"  # or duckdb / sqlite3 / pandas — it's a plain SQLite file
 ```
 
-`forum query` opens the cache **read-only**, so a query can never modify it; table output by default, `--json` emits rows as an array of objects. The `posts` table has typed columns (`id`, `topic_id`, `post_number`, `username`, `created_at`, `cooked`, …) plus a `raw` column with each post's full JSON.
+`forum query` opens the cache **read-only**, so a query can never modify it; table output by default, `--json` emits rows as an array of objects. The `posts` table has typed columns (`id`, `topic_id`, `post_number`, `username`, `created_at`, `cooked`, …), a **`text`** column with the HTML stripped (query this, not `cooked`, for token-cheap reading), and a `raw` column with each post's full JSON (reach any other Discourse field via `json_extract(raw, '$.score')` etc.).
+
+**Model-judgment analysis (summary, sentiment) is done by the agent, not the CLI.** The CLI just serves clean, sliceable data; an agent does the reasoning with its own model — e.g. pull the latest 40 posts' `text` to be caught up, chunk a long thread by `post_number` ranges to summarize it (map-reduce), or classify a high-`score` slice for bull-vs-bear. The installed skills include these query recipes.
 
 ## Upgrade
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -88,6 +88,7 @@ impl Cache {
                     created_at  TEXT,
                     updated_at  TEXT,
                     cooked      TEXT,
+                    text        TEXT,
                     raw         TEXT,
                     fetched_at  TEXT
                  );
@@ -95,6 +96,45 @@ impl Cache {
                     ON posts(topic_id, post_number);",
             )
             .context("migrating forum cache schema")?;
+
+        // Caches created before the clean-text column need it added and
+        // backfilled once (CREATE TABLE IF NOT EXISTS won't alter an existing
+        // table).
+        let has_text: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('posts') WHERE name = 'text'",
+            [],
+            |r| r.get(0),
+        )?;
+        if has_text == 0 {
+            self.conn
+                .execute("ALTER TABLE posts ADD COLUMN text TEXT", [])
+                .context("adding text column")?;
+            self.backfill_text()?;
+        }
+        Ok(())
+    }
+
+    /// One-time backfill of the `text` column from `cooked` for rows that
+    /// predate it.
+    fn backfill_text(&self) -> Result<()> {
+        let pending: Vec<(i64, Option<String>)> = {
+            let mut stmt = self
+                .conn
+                .prepare("SELECT id, cooked FROM posts WHERE text IS NULL")?;
+            let rows = stmt
+                .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            rows
+        };
+        let tx = self.conn.unchecked_transaction()?;
+        for (id, cooked) in pending {
+            let text = cooked.as_deref().map(crate::forum::strip_html);
+            tx.execute(
+                "UPDATE posts SET text = ?1 WHERE id = ?2",
+                params![text, id],
+            )?;
+        }
+        tx.commit()?;
         Ok(())
     }
 
@@ -146,14 +186,15 @@ impl Cache {
         {
             let mut stmt = tx.prepare(
                 "INSERT INTO posts
-                    (id, topic_id, post_number, username, created_at, updated_at, cooked, raw, fetched_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, datetime('now'))
+                    (id, topic_id, post_number, username, created_at, updated_at, cooked, text, raw, fetched_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, datetime('now'))
                  ON CONFLICT(id) DO UPDATE SET
                     post_number = excluded.post_number,
                     username    = excluded.username,
                     created_at  = excluded.created_at,
                     updated_at  = excluded.updated_at,
                     cooked      = excluded.cooked,
+                    text        = excluded.text,
                     raw         = excluded.raw,
                     fetched_at  = excluded.fetched_at",
             )?;
@@ -161,6 +202,8 @@ impl Cache {
                 let Some(id) = p.get("id").and_then(Value::as_i64) else {
                     continue;
                 };
+                let cooked = p.get("cooked").and_then(Value::as_str);
+                let text = cooked.map(crate::forum::strip_html);
                 stmt.execute(params![
                     id,
                     topic_id,
@@ -168,7 +211,8 @@ impl Cache {
                     p.get("username").and_then(Value::as_str),
                     p.get("created_at").and_then(Value::as_str),
                     p.get("updated_at").and_then(Value::as_str),
-                    p.get("cooked").and_then(Value::as_str),
+                    cooked,
+                    text,
                     serde_json::to_string(p)?,
                 ])?;
                 count += 1;
@@ -435,6 +479,45 @@ mod tests {
                 || format!("{err:#}").to_lowercase().contains("read only"),
             "got: {err:#}"
         );
+    }
+
+    #[test]
+    fn upsert_populates_clean_text_column() {
+        let c = Cache::open_in_memory().unwrap();
+        c.upsert_posts(
+            7,
+            &[json!({"id": 1, "post_number": 1, "cooked": "<p>Hello <b>world</b></p>"})],
+        )
+        .unwrap();
+        let r = c.query("SELECT text FROM posts WHERE id = 1").unwrap();
+        assert_eq!(r.rows[0][0], json!("Hello world"));
+    }
+
+    #[test]
+    fn migration_adds_and_backfills_text_for_old_caches() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("old.db");
+        {
+            // Simulate a pre-`text` cache: posts table without the column.
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE posts (id INTEGER PRIMARY KEY, topic_id INTEGER NOT NULL,
+                    post_number INTEGER, username TEXT, created_at TEXT, updated_at TEXT,
+                    cooked TEXT, raw TEXT, fetched_at TEXT);
+                 CREATE TABLE topics (id INTEGER PRIMARY KEY, title TEXT, posts_count INTEGER,
+                    last_page INTEGER NOT NULL DEFAULT 0, synced_at TEXT);",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO posts (id, topic_id, cooked) VALUES (1, 7, '<p>Hi <b>there</b></p>')",
+                [],
+            )
+            .unwrap();
+        }
+        // Opening migrates: adds the column and backfills from cooked.
+        let c = Cache::open_at(&path).unwrap();
+        let r = c.query("SELECT text FROM posts WHERE id = 1").unwrap();
+        assert_eq!(r.rows[0][0], json!("Hi there"));
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -57,6 +57,13 @@ impl Cache {
                 path.display()
             );
         }
+        // Bring the schema up to date first — a pre-`text` cache needs the
+        // column added + backfilled, and migrate() needs a writable connection.
+        // Run that pass, then reopen read-only for the actual query, so the
+        // user's SQL still runs against a read-only connection and can't mutate
+        // the cache. Without this, `forum query "... text ..."` on an old cache
+        // would fail with "no such column: text".
+        Self::open_at(path)?;
         let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
             .with_context(|| format!("opening forum cache (read-only) at {}", path.display()))?;
         Ok(Self { conn })
@@ -518,6 +525,35 @@ mod tests {
         let c = Cache::open_at(&path).unwrap();
         let r = c.query("SELECT text FROM posts WHERE id = 1").unwrap();
         assert_eq!(r.rows[0][0], json!("Hi there"));
+    }
+
+    #[test]
+    fn open_readonly_migrates_old_cache_so_text_is_queryable() {
+        // A pre-`text` cache queried via the read-only path must still be
+        // upgraded first, or `SELECT text` would fail with "no such column".
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("old.db");
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE posts (id INTEGER PRIMARY KEY, topic_id INTEGER NOT NULL,
+                    post_number INTEGER, username TEXT, created_at TEXT, updated_at TEXT,
+                    cooked TEXT, raw TEXT, fetched_at TEXT);
+                 CREATE TABLE topics (id INTEGER PRIMARY KEY, title TEXT, posts_count INTEGER,
+                    last_page INTEGER NOT NULL DEFAULT 0, synced_at TEXT);",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO posts (id, topic_id, cooked) VALUES (1, 7, '<p>Hi</p>')",
+                [],
+            )
+            .unwrap();
+        }
+        let ro = Cache::open_readonly_at(&path).unwrap();
+        let r = ro.query("SELECT text FROM posts WHERE id = 1").unwrap();
+        assert_eq!(r.rows[0][0], json!("Hi"));
+        // And it's still read-only.
+        assert!(ro.query("DELETE FROM posts").is_err());
     }
 
     #[test]

--- a/src/forum.rs
+++ b/src/forum.rs
@@ -296,8 +296,9 @@ fn blurb_for_topic(posts: &[Value], topic_id: i64) -> Option<String> {
 /// Best-effort HTML → text for terminal reading: map block boundaries to
 /// newlines (so multi-paragraph posts stay readable), drop remaining tags,
 /// collapse intra-line whitespace while keeping line breaks, then decode the
-/// handful of entities Discourse emits. Not a parser.
-fn strip_html(s: &str) -> String {
+/// handful of entities Discourse emits. Not a parser. Also used by the cache to
+/// populate the clean-text `text` column.
+pub(crate) fn strip_html(s: &str) -> String {
     let with_breaks = s
         .replace("</p>", "\n\n")
         .replace("<br>", "\n")

--- a/src/skill/hermes.md
+++ b/src/skill/hermes.md
@@ -61,6 +61,16 @@ inderes forum db-path             # path to the local SQLite cache
 
 Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`. Cached posts are queryable with `inderes forum query "<SQL>"` (read-only) — e.g. most active users on a stock, or posting volume over time.
 
+## Analyzing cached threads (you reason, the CLI only serves data)
+
+The cache has a clean-text `text` column (HTML stripped) — query `text`, not `cooked`, to save tokens. Cache a topic first with `inderes forum topic <id>`, then:
+
+- **Catch me up** (recent posts): `inderes --json forum query "SELECT post_number, username, date(created_at) d, text FROM posts WHERE topic_id=74 ORDER BY post_number DESC LIMIT 40"` → summarize the result yourself.
+- **Summarize a long thread** (map-reduce — a big thread won't fit in context): pull it in chunks, summarize each, then combine. Get the size with `SELECT MAX(post_number) FROM posts WHERE topic_id=74`, then `... WHERE topic_id=74 AND post_number BETWEEN 1 AND 500 ORDER BY post_number` (repeat for 501–1000, …).
+- **Sentiment / bull-vs-bear**: classify a representative slice — the posts the thread reacted to, plus the latest: `inderes --json forum query "SELECT username, text, json_extract(raw,'$.score') score FROM posts WHERE topic_id=74 ORDER BY score DESC LIMIT 50"`.
+
+The CLI never summarizes or scores — it returns rows; you do the judgment with your own model.
+
 ## Procedure
 
 1. Parse what the user needs — fundamentals, estimates, a specific report, an event, an insider trade, etc.

--- a/src/skill/openclaw.md
+++ b/src/skill/openclaw.md
@@ -59,6 +59,16 @@ inderes forum db-path             # path to the local SQLite cache
 
 Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`. Cached posts are queryable with `inderes forum query "<SQL>"` (read-only) — e.g. most active users on a stock, or posting volume over time.
 
+## Analyzing cached threads (you reason, the CLI only serves data)
+
+The cache has a clean-text `text` column (HTML stripped) — query `text`, not `cooked`, to save tokens. Cache a topic first with `inderes forum topic <id>`, then:
+
+- **Catch me up** (recent posts): `inderes --json forum query "SELECT post_number, username, date(created_at) d, text FROM posts WHERE topic_id=74 ORDER BY post_number DESC LIMIT 40"` → summarize the result yourself.
+- **Summarize a long thread** (map-reduce — a big thread won't fit in context): pull it in chunks, summarize each, then combine. Get the size with `SELECT MAX(post_number) FROM posts WHERE topic_id=74`, then `... WHERE topic_id=74 AND post_number BETWEEN 1 AND 500 ORDER BY post_number` (repeat for 501–1000, …).
+- **Sentiment / bull-vs-bear**: classify a representative slice — the posts the thread reacted to, plus the latest: `inderes --json forum query "SELECT username, text, json_extract(raw,'$.score') score FROM posts WHERE topic_id=74 ORDER BY score DESC LIMIT 50"`.
+
+The CLI never summarizes or scores — it returns rows; you do the judgment with your own model.
+
 ## Escape hatch: all 16 tools
 
 The server exposes more tools than the friendly subcommands wrap. To see everything:

--- a/src/skill/ptrclaw.md
+++ b/src/skill/ptrclaw.md
@@ -56,6 +56,16 @@ inderes forum db-path             # path to the local SQLite cache
 
 Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`. Cached posts are queryable with `inderes forum query "<SQL>"` (read-only) — e.g. most active users on a stock, or posting volume over time.
 
+## Analyzing cached threads (you reason, the CLI only serves data)
+
+The cache has a clean-text `text` column (HTML stripped) — query `text`, not `cooked`, to save tokens. Cache a topic first with `inderes forum topic <id>`, then:
+
+- **Catch me up** (recent posts): `inderes --json forum query "SELECT post_number, username, date(created_at) d, text FROM posts WHERE topic_id=74 ORDER BY post_number DESC LIMIT 40"` → summarize the result yourself.
+- **Summarize a long thread** (map-reduce — a big thread won't fit in context): pull it in chunks, summarize each, then combine. Get the size with `SELECT MAX(post_number) FROM posts WHERE topic_id=74`, then `... WHERE topic_id=74 AND post_number BETWEEN 1 AND 500 ORDER BY post_number` (repeat for 501–1000, …).
+- **Sentiment / bull-vs-bear**: classify a representative slice — the posts the thread reacted to, plus the latest: `inderes --json forum query "SELECT username, text, json_extract(raw,'$.score') score FROM posts WHERE topic_id=74 ORDER BY score DESC LIMIT 50"`.
+
+The CLI never summarizes or scores — it returns rows; you do the judgment with your own model.
+
 ## Procedure
 
 1. Parse what the user needs — fundamentals, estimates, a specific report, an event, an insider trade, etc.


### PR DESCRIPTION
## What

Makes agent-side analysis of the cached forum corpus easy, without putting an LLM in the CLI.

1. **`text` column** on cached posts — `cooked` with HTML stripped (via the shared `strip_html`). Agents query `text` instead of `cooked` for token-cheap, markup-free content. Populated on upsert; existing caches get the column **added and backfilled once** on next open (CREATE TABLE IF NOT EXISTS can't alter an existing table).
2. **Analysis recipes** in README + all three skills for the model-judgment workflows:
   - catch-me-up (latest N posts' `text`),
   - long-thread summary via map-reduce over `post_number` chunks (a big thread won't fit in context),
   - sentiment / bull-vs-bear by classifying a high-`score` slice.

## Boundary

The CLI still does **no** summarization or scoring — it serves clean, sliceable data; the agent reasons with its own model. Keeps API keys / an LLM dependency out of the CLI, consistent with its agent-driven design.

## Testing

- cache: `text` populated + stripped on upsert; migration adds + backfills `text` for a simulated pre-`text` cache.
- `fmt` + `clippy -D warnings` + `cargo test --all-targets` (155 tests) + markdownlint clean.
- Live: `text` column returns markup-free content; recipe queries (recent slice, high-score slice) work.

> Note: Codex was at its workspace credit limit, so this relies on the workflow self-review plus local tests.
