### PR TITLE
feat(forum): activity timeline + momentum read

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ datasette "$(inderes forum db-path)"  # or duckdb / sqlite3 / pandas — it's a 
 
 `forum activity <id>` buckets posts by day/week/month (`--bucket`, `--periods`) and prints a small bar chart plus a momentum read — whether the thread is heating up or cooling off (latest bucket vs the average of the rest). It's an attention signal over your cached data, so refresh the topic first for a current picture.
 
+Two tiers of analysis sit on the cache:
+
+- **Deterministic** (the CLI computes it): activity/momentum, top posters, posting volume — via `forum activity` and `forum query`. Exact, reproducible, no model.
+- **Model-judgment** (an agent does it): thread summary / catch-me-up and sentiment / bull-vs-bear, by reasoning over the clean `text` column using the recipes in the installed skills. The CLI never calls a model — it just serves the data.
+
 `forum query` opens the cache **read-only**, so a query can never modify it; table output by default, `--json` emits rows as an array of objects. The `posts` table has typed columns (`id`, `topic_id`, `post_number`, `username`, `created_at`, `cooked`, …), a **`text`** column with the HTML stripped (query this, not `cooked`, for token-cheap reading), and a `raw` column with each post's full JSON (reach any other Discourse field via `json_extract(raw, '$.score')` etc.).
 
 **Model-judgment analysis (summary, sentiment) is done by the agent, not the CLI.** The CLI just serves clean, sliceable data; an agent does the reasoning with its own model — e.g. pull the latest 40 posts' `text` to be caught up, chunk a long thread by `post_number` ranges to summarize it (map-reduce), or classify a high-`score` slice for bull-vs-bear. The installed skills include these query recipes.

--- a/README.md
+++ b/README.md
@@ -146,11 +146,14 @@ inderes --json forum topic 74 | jq '.post_stream.posts[].cooked'
 **Analyzing the cache.** Once topics are cached, query them with SQL straight from the CLI, or point your own tools at the database file:
 
 ```bash
+inderes forum activity 74             # posting volume over time + a momentum read
 inderes forum db-path                 # path to the SQLite file
 inderes forum query "SELECT username, COUNT(*) n FROM posts GROUP BY username ORDER BY n DESC LIMIT 10"
 inderes --json forum query "SELECT date(created_at) d, COUNT(*) c FROM posts GROUP BY d ORDER BY d"
 datasette "$(inderes forum db-path)"  # or duckdb / sqlite3 / pandas — it's a plain SQLite file
 ```
+
+`forum activity <id>` buckets posts by day/week/month (`--bucket`, `--periods`) and prints a small bar chart plus a momentum read — whether the thread is heating up or cooling off (latest bucket vs the average of the rest). It's an attention signal over your cached data, so refresh the topic first for a current picture.
 
 `forum query` opens the cache **read-only**, so a query can never modify it; table output by default, `--json` emits rows as an array of objects. The `posts` table has typed columns (`id`, `topic_id`, `post_number`, `username`, `created_at`, `cooked`, …), a **`text`** column with the HTML stripped (query this, not `cooked`, for token-cheap reading), and a `raw` column with each post's full JSON (reach any other Discourse field via `json_extract(raw, '$.score')` etc.).
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -291,6 +291,40 @@ impl Cache {
         Ok(QueryResult { columns, rows })
     }
 
+    /// Post counts per time bucket for a topic — the most recent `limit`
+    /// buckets, returned chronologically (ascending). `bucket` is
+    /// day/week/month. Empty buckets (no posts) are omitted.
+    pub fn activity(&self, topic_id: i64, bucket: &str, limit: u32) -> Result<Vec<(String, i64)>> {
+        // `bucket` is validated to a fixed set, so interpolating the format is
+        // not an injection vector.
+        let fmt = match bucket {
+            "day" => "%Y-%m-%d",
+            "week" => "%Y-W%W",
+            "month" => "%Y-%m",
+            other => bail!("invalid bucket {other:?}: use day, week, or month"),
+        };
+        let sql = format!(
+            "SELECT period, n FROM (
+                 SELECT strftime('{fmt}', created_at) AS period, COUNT(*) AS n
+                 FROM posts
+                 WHERE topic_id = ?1 AND created_at IS NOT NULL
+                 GROUP BY period
+                 ORDER BY period DESC
+                 LIMIT ?2
+             ) ORDER BY period ASC",
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(params![topic_id, limit], |r| {
+                Ok((
+                    r.get::<_, Option<String>>(0)?.unwrap_or_default(),
+                    r.get::<_, i64>(1)?,
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
     pub fn topic_title(&self, topic_id: i64) -> Result<Option<String>> {
         Ok(self
             .conn
@@ -486,6 +520,31 @@ mod tests {
                 || format!("{err:#}").to_lowercase().contains("read only"),
             "got: {err:#}"
         );
+    }
+
+    #[test]
+    fn activity_buckets_posts_by_period() {
+        let c = Cache::open_in_memory().unwrap();
+        c.upsert_posts(
+            7,
+            &[
+                json!({"id":1,"post_number":1,"created_at":"2026-01-05T10:00:00Z","cooked":"a"}),
+                json!({"id":2,"post_number":2,"created_at":"2026-01-06T10:00:00Z","cooked":"b"}),
+                json!({"id":3,"post_number":3,"created_at":"2026-01-20T10:00:00Z","cooked":"c"}),
+            ],
+        )
+        .unwrap();
+        let series = c.activity(7, "week", 12).unwrap();
+        // Two distinct weeks (validates strftime parses the ISO8601 created_at).
+        assert_eq!(series.len(), 2, "got: {series:?}");
+        assert_eq!(series.iter().map(|(_, n)| n).sum::<i64>(), 3);
+        assert!(series.windows(2).all(|w| w[0].0 <= w[1].0)); // ascending
+    }
+
+    #[test]
+    fn activity_rejects_unknown_bucket() {
+        let c = Cache::open_in_memory().unwrap();
+        assert!(c.activity(7, "fortnight", 12).is_err());
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -295,17 +295,21 @@ impl Cache {
     /// buckets, returned chronologically (ascending). `bucket` is
     /// day/week/month. Empty buckets (no posts) are omitted.
     pub fn activity(&self, topic_id: i64, bucket: &str, limit: u32) -> Result<Vec<(String, i64)>> {
-        // `bucket` is validated to a fixed set, so interpolating the format is
-        // not an injection vector.
-        let fmt = match bucket {
-            "day" => "%Y-%m-%d",
-            "week" => "%Y-W%W",
-            "month" => "%Y-%m",
+        // `bucket` is validated to a fixed set, so interpolating the expression
+        // is not an injection vector. Weeks bucket by the Monday-of-week *date*
+        // rather than strftime %W: %Y/%W disagree across New Year (e.g.
+        // 2025-12-31 -> 2025-W52 but 2026-01-01 -> 2026-W00), which would split
+        // one real week into two buckets.
+        let period_expr = match bucket {
+            "day" => "strftime('%Y-%m-%d', created_at)".to_string(),
+            "week" => "date(created_at, '-' || ((strftime('%w', created_at) + 6) % 7) || ' days')"
+                .to_string(),
+            "month" => "strftime('%Y-%m', created_at)".to_string(),
             other => bail!("invalid bucket {other:?}: use day, week, or month"),
         };
         let sql = format!(
             "SELECT period, n FROM (
-                 SELECT strftime('{fmt}', created_at) AS period, COUNT(*) AS n
+                 SELECT {period_expr} AS period, COUNT(*) AS n
                  FROM posts
                  WHERE topic_id = ?1 AND created_at IS NOT NULL
                  GROUP BY period
@@ -539,6 +543,28 @@ mod tests {
         assert_eq!(series.len(), 2, "got: {series:?}");
         assert_eq!(series.iter().map(|(_, n)| n).sum::<i64>(), 3);
         assert!(series.windows(2).all(|w| w[0].0 <= w[1].0)); // ascending
+    }
+
+    #[test]
+    fn activity_week_bucket_does_not_split_across_new_year() {
+        // 2025-12-31 (Wed) and 2026-01-01 (Thu) are the same Mon-start week;
+        // strftime %W would split them (2025-W52 vs 2026-W00).
+        let c = Cache::open_in_memory().unwrap();
+        c.upsert_posts(
+            7,
+            &[
+                json!({"id":1,"post_number":1,"created_at":"2025-12-31T10:00:00Z","cooked":"a"}),
+                json!({"id":2,"post_number":2,"created_at":"2026-01-01T10:00:00Z","cooked":"b"}),
+            ],
+        )
+        .unwrap();
+        let series = c.activity(7, "week", 12).unwrap();
+        assert_eq!(
+            series.len(),
+            1,
+            "same week must be one bucket, got: {series:?}"
+        );
+        assert_eq!(series[0].1, 2);
     }
 
     #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -416,6 +416,87 @@ pub fn forum_query(ctx: &ToolCtx<'_>, sql: &str) -> Result<()> {
     Ok(())
 }
 
+/// Show posting activity over time for a cached topic — a per-bucket timeline
+/// plus a momentum read (latest bucket vs the average of the others).
+pub fn forum_activity(ctx: &ToolCtx<'_>, id: &str, bucket: &str, periods: u32) -> Result<()> {
+    let topic_id: i64 = id
+        .parse()
+        .map_err(|_| anyhow!("invalid topic id {id:?}: expected a number"))?;
+    let cache = cache::Cache::open_readonly()?;
+    let series = cache.activity(topic_id, bucket, periods)?;
+    if series.is_empty() {
+        bail!("no cached posts for topic {id} — run `inderes forum topic {id}` first");
+    }
+    if ctx.json_output {
+        let mut obj = Map::new();
+        obj.insert("bucket".into(), json!(bucket));
+        obj.insert(
+            "periods".into(),
+            Value::Array(
+                series
+                    .iter()
+                    .map(|(p, n)| json!({ "period": p, "count": n }))
+                    .collect(),
+            ),
+        );
+        if let Some((latest, avg, ratio)) = momentum(&series) {
+            obj.insert(
+                "momentum".into(),
+                json!({
+                    "latest": latest,
+                    "baseline_avg": (avg * 100.0).round() / 100.0,
+                    "ratio": (ratio * 100.0).round() / 100.0,
+                }),
+            );
+        }
+        println!("{}", serde_json::to_string_pretty(&Value::Object(obj))?);
+    } else {
+        print!("{}", render_activity(topic_id, bucket, &series));
+    }
+    Ok(())
+}
+
+/// `(latest_count, baseline_avg_of_earlier_periods, ratio)`. `None` with fewer
+/// than two periods (nothing to compare against).
+fn momentum(series: &[(String, i64)]) -> Option<(i64, f64, f64)> {
+    if series.len() < 2 {
+        return None;
+    }
+    let latest = series[series.len() - 1].1;
+    let earlier = &series[..series.len() - 1];
+    let avg = earlier.iter().map(|(_, n)| *n as f64).sum::<f64>() / earlier.len() as f64;
+    let ratio = if avg > 0.0 {
+        latest as f64 / avg
+    } else {
+        f64::INFINITY
+    };
+    Some((latest, avg, ratio))
+}
+
+/// Render the activity timeline as a small bar chart plus a momentum line.
+fn render_activity(topic_id: i64, bucket: &str, series: &[(String, i64)]) -> String {
+    let mut out = format!("Activity for topic #{topic_id} (by {bucket})\n");
+    let max = series.iter().map(|(_, n)| *n).max().unwrap_or(0).max(1);
+    for (p, n) in series {
+        let bar = "█".repeat(((*n as f64 / max as f64) * 24.0).round() as usize);
+        out.push_str(&format!("{p:<10}  {n:>5}  {bar}\n"));
+    }
+    if let Some((latest, avg, ratio)) = momentum(series) {
+        let label = if ratio >= 1.5 {
+            "heating up"
+        } else if ratio <= 0.66 {
+            "cooling off"
+        } else {
+            "steady"
+        };
+        out.push_str(&format!(
+            "\nMomentum: {latest} in the latest {bucket} vs {avg:.0} avg — {ratio:.1}x ({label})\n"
+        ));
+    }
+    out.push_str("(reflects cached posts; run `inderes forum topic` to refresh)\n");
+    out
+}
+
 /// Render query results as a simple column-aligned text table.
 fn render_query_table(r: &cache::QueryResult) -> String {
     if r.columns.is_empty() {
@@ -946,6 +1027,38 @@ mod tests {
     fn build_args_empty_yields_empty_object() {
         let args = build_args(vec![], None).unwrap();
         assert_eq!(args, json!({}));
+    }
+
+    // --- momentum / render_activity ---------------------------------------
+
+    #[test]
+    fn momentum_compares_latest_to_baseline() {
+        let s = vec![
+            ("w1".to_string(), 10i64),
+            ("w2".to_string(), 10),
+            ("w3".to_string(), 30),
+        ];
+        let (latest, avg, ratio) = momentum(&s).unwrap();
+        assert_eq!(latest, 30);
+        assert_eq!(avg, 10.0);
+        assert_eq!(ratio, 3.0);
+    }
+
+    #[test]
+    fn momentum_is_none_with_one_period() {
+        assert!(momentum(&[("w1".to_string(), 5i64)]).is_none());
+    }
+
+    #[test]
+    fn render_activity_shows_bars_and_momentum_label() {
+        let s = vec![
+            ("2026-W01".to_string(), 10i64),
+            ("2026-W02".to_string(), 30),
+        ];
+        let out = render_activity(7, "week", &s);
+        assert!(out.contains("topic #7"));
+        assert!(out.contains("Momentum"));
+        assert!(out.contains("heating up"), "got: {out}");
     }
 
     // --- render_query_table -----------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ mod upgrade;
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::{ArgAction, Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 
 pub const DEFAULT_ENDPOINT: &str = "https://mcp.inderes.com/";
@@ -233,8 +233,36 @@ enum ForumCmd {
         /// SQL to run (e.g. "SELECT username, COUNT(*) FROM posts GROUP BY username").
         sql: String,
     },
+    /// Show posting activity over time (momentum) for a cached topic.
+    Activity {
+        /// Numeric topic ID.
+        id: String,
+        /// Time bucket to group by.
+        #[arg(long, value_enum, default_value_t = Bucket::Week)]
+        bucket: Bucket,
+        /// Number of most-recent buckets to show.
+        #[arg(long, default_value_t = 12)]
+        periods: u32,
+    },
     /// Print the path to the local forum cache database.
     DbPath,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Bucket {
+    Day,
+    Week,
+    Month,
+}
+
+impl Bucket {
+    fn as_str(self) -> &'static str {
+        match self {
+            Bucket::Day => "day",
+            Bucket::Week => "week",
+            Bucket::Month => "month",
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -348,6 +376,11 @@ async fn run() -> Result<()> {
         Command::Forum(ForumCmd::Latest) => commands::forum_latest(&ctx).await,
         Command::Forum(ForumCmd::Categories) => commands::forum_categories(&ctx).await,
         Command::Forum(ForumCmd::Query { sql }) => commands::forum_query(&ctx, &sql),
+        Command::Forum(ForumCmd::Activity {
+            id,
+            bucket,
+            periods,
+        }) => commands::forum_activity(&ctx, &id, bucket.as_str(), periods),
         Command::Forum(ForumCmd::DbPath) => commands::forum_db_path(),
 
         Command::Call {

--- a/src/skill/hermes.md
+++ b/src/skill/hermes.md
@@ -56,6 +56,7 @@ inderes forum topic 74 --refresh  # re-fetch from page 1, updating edits
 inderes forum latest              # latest active topics
 inderes forum categories          # category list
 inderes forum query "<SQL>"       # read-only SQL over the cached posts
+inderes forum activity 74         # posting volume over time (momentum)
 inderes forum db-path             # path to the local SQLite cache
 ```
 

--- a/src/skill/openclaw.md
+++ b/src/skill/openclaw.md
@@ -54,6 +54,7 @@ inderes forum topic 74 --refresh  # re-fetch from page 1, updating edits
 inderes forum latest              # latest active topics
 inderes forum categories          # category list
 inderes forum query "<SQL>"       # read-only SQL over the cached posts
+inderes forum activity 74         # posting volume over time (momentum)
 inderes forum db-path             # path to the local SQLite cache
 ```
 

--- a/src/skill/ptrclaw.md
+++ b/src/skill/ptrclaw.md
@@ -51,6 +51,7 @@ inderes forum topic 74 --refresh  # re-fetch from page 1, updating edits
 inderes forum latest              # latest active topics
 inderes forum categories          # category list
 inderes forum query "<SQL>"       # read-only SQL over the cached posts
+inderes forum activity 74         # posting volume over time (momentum)
 inderes forum db-path             # path to the local SQLite cache
 ```
 


### PR DESCRIPTION
## What

Adds `inderes forum activity <id>` — posting **momentum** for a cached topic.

- Buckets cached posts by `--bucket day|week|month` (default week), most recent `--periods` (default 12), returned chronologically.
- Prints a small bar chart per bucket plus a **momentum read**: the latest bucket vs the average of the rest, labelled *heating up* / *steady* / *cooling off*.
- `--json` for agents (periods array + momentum object).

This turns "stats" from vanity counts into an actual signal: is discussion around a company accelerating or fading.

## Honest framing

It's an **attention/interest** signal over the **cached** corpus — coincident/noisy, not alpha, and only as fresh as your last `forum topic`. Output says so. Deterministic (pure SQL bucketing + arithmetic) — no model involved; that stays agent-side.

## Notes

- `cache.activity()` does the `strftime` bucketing over `created_at` (bucket validated to a fixed set — no SQL injection). Momentum + rendering live in `commands`.
- Documented in README + all three skills.

## Testing

- cache: bucketing groups by period and parses ISO8601 `created_at` (two-week fixture); unknown bucket rejected.
- commands: momentum ratio math; `None` with one period; renderer shows bars + label.
- `fmt` + `clippy -D warnings` + `cargo test` (161 tests) + markdownlint clean.
- Live: weekly chart + "cooling off" read on a real thread; `--bucket month --json` verified.
