### PR TITLE
feat(forum): cache management (topics, clear, refresh-all)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,17 @@ Two tiers of analysis sit on the cache:
 - **Deterministic** (the CLI computes it): activity/momentum, top posters, posting volume — via `forum activity` and `forum query`. Exact, reproducible, no model.
 - **Model-judgment** (an agent does it): thread summary / catch-me-up and sentiment / bull-vs-bear, by reasoning over the clean `text` column using the recipes in the installed skills. The CLI never calls a model — it just serves the data.
 
+**Managing the cache.**
+
+```bash
+inderes forum topics         # list cached topics (id, post count, last synced)
+inderes forum refresh-all    # pull new posts for every cached topic (incremental)
+inderes forum clear 74       # drop one topic from the cache
+inderes forum clear --all    # wipe the cache (prompts; --yes to skip)
+```
+
+`refresh-all` keeps a whole watchlist current in one go, so cross-topic comparisons (e.g. which thread's `activity` is accelerating) stay meaningful.
+
 `forum query` opens the cache **read-only**, so a query can never modify it; table output by default, `--json` emits rows as an array of objects. The `posts` table has typed columns (`id`, `topic_id`, `post_number`, `username`, `created_at`, `cooked`, …), a **`text`** column with the HTML stripped (query this, not `cooked`, for token-cheap reading), and a `raw` column with each post's full JSON (reach any other Discourse field via `json_extract(raw, '$.score')` etc.).
 
 **Model-judgment analysis (summary, sentiment) is done by the agent, not the CLI.** The CLI just serves clean, sliceable data; an agent does the reasoning with its own model — e.g. pull the latest 40 posts' `text` to be caught up, chunk a long thread by `post_number` ranges to summarize it (map-reduce), or classify a high-`score` slice for bull-vs-bear. The installed skills include these query recipes.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -346,6 +346,63 @@ impl Cache {
             |r| r.get(0),
         )?)
     }
+
+    /// Inventory of cached topics (most recently synced first), with the actual
+    /// number of posts stored for each.
+    pub fn list_cached(&self) -> Result<Vec<CachedTopic>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT t.id, t.title,
+                    (SELECT COUNT(*) FROM posts p WHERE p.topic_id = t.id) AS posts,
+                    t.synced_at
+             FROM topics t
+             ORDER BY t.synced_at DESC",
+        )?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok(CachedTopic {
+                    id: r.get(0)?,
+                    title: r.get(1)?,
+                    posts: r.get(2)?,
+                    synced_at: r.get(3)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// IDs of all cached topics (for `refresh-all`).
+    pub fn cached_topic_ids(&self) -> Result<Vec<i64>> {
+        let mut stmt = self.conn.prepare("SELECT id FROM topics ORDER BY id")?;
+        let ids = stmt
+            .query_map([], |r| r.get::<_, i64>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(ids)
+    }
+
+    /// Remove one topic's posts and its metadata row.
+    pub fn clear_topic(&self, topic_id: i64) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM posts WHERE topic_id = ?1", [topic_id])?;
+        self.conn
+            .execute("DELETE FROM topics WHERE id = ?1", [topic_id])?;
+        Ok(())
+    }
+
+    /// Wipe the entire cache.
+    pub fn clear_all(&self) -> Result<()> {
+        self.conn
+            .execute_batch("DELETE FROM posts; DELETE FROM topics;")?;
+        Ok(())
+    }
+}
+
+/// One row of the cached-topic inventory ([`Cache::list_cached`]).
+#[derive(Debug)]
+pub struct CachedTopic {
+    pub id: i64,
+    pub title: Option<String>,
+    pub posts: i64,
+    pub synced_at: Option<String>,
 }
 
 /// Columns and rows returned by [`Cache::query`]; each row is one value per
@@ -670,6 +727,48 @@ mod tests {
             format!("{err:#}").contains("no forum cache"),
             "got: {err:#}"
         );
+    }
+
+    #[test]
+    fn list_cached_reports_topics_with_post_counts() {
+        let c = Cache::open_in_memory().unwrap();
+        c.upsert_posts(7, &[post(1, 1, "a", "x"), post(2, 2, "a", "y")])
+            .unwrap();
+        c.set_topic_meta(7, Some("Topic Seven"), Some(2), 1)
+            .unwrap();
+        c.upsert_posts(8, &[post(3, 1, "b", "z")]).unwrap();
+        c.set_topic_meta(8, Some("Eight"), Some(1), 1).unwrap();
+        let list = c.list_cached().unwrap();
+        assert_eq!(list.len(), 2);
+        let seven = list.iter().find(|t| t.id == 7).unwrap();
+        assert_eq!(seven.posts, 2);
+        assert_eq!(seven.title.as_deref(), Some("Topic Seven"));
+    }
+
+    #[test]
+    fn clear_topic_and_clear_all() {
+        let c = Cache::open_in_memory().unwrap();
+        c.upsert_posts(7, &[post(1, 1, "a", "x")]).unwrap();
+        c.set_topic_meta(7, Some("S"), Some(1), 1).unwrap();
+        c.upsert_posts(8, &[post(2, 1, "b", "y")]).unwrap();
+        c.set_topic_meta(8, Some("E"), Some(1), 1).unwrap();
+
+        c.clear_topic(7).unwrap();
+        assert_eq!(c.post_count(7).unwrap(), 0);
+        assert_eq!(c.post_count(8).unwrap(), 1);
+        assert_eq!(c.list_cached().unwrap().len(), 1);
+
+        c.clear_all().unwrap();
+        assert_eq!(c.list_cached().unwrap().len(), 0);
+        assert_eq!(c.post_count(8).unwrap(), 0);
+    }
+
+    #[test]
+    fn cached_topic_ids_lists_all() {
+        let c = Cache::open_in_memory().unwrap();
+        c.set_topic_meta(7, None, None, 1).unwrap();
+        c.set_topic_meta(8, None, None, 1).unwrap();
+        assert_eq!(c.cached_topic_ids().unwrap(), vec![7, 8]);
     }
 
     #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -268,22 +268,12 @@ pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str, refresh: bool) -> Result<(
     } else {
         cache.last_page(topic_id)?.max(1)
     };
-    let (mut fetched_any, interrupted) =
-        walk_topic_pages(&client, &cache, id, topic_id, start).await?;
-
-    // A resumed walk (start > 1) that 404s immediately without fetching and
-    // without erroring is ambiguous: either the thread shrank below the cached
-    // watermark, or the topic was deleted / made private. Re-verify from page 1
-    // — that re-walks a shrunk thread (lowering the watermark) or confirms the
-    // topic is gone (so we don't silently pass off stale cache as fresh).
-    if !fetched_any && !interrupted && start > 1 {
-        (fetched_any, _) = walk_topic_pages(&client, &cache, id, topic_id, 1).await?;
-        if !fetched_any && cache.post_count(topic_id)? > 0 {
-            eprintln!(
-                "warning: forum topic {id} returned 404 (deleted or made private); \
-                 serving the cached copy."
-            );
-        }
+    let (fetched_any, _) = fetch_topic_incremental(&client, &cache, id, topic_id, start).await?;
+    if !fetched_any && start > 1 && cache.post_count(topic_id)? > 0 {
+        eprintln!(
+            "warning: forum topic {id} returned 404 (deleted or made private); \
+             serving the cached copy."
+        );
     }
 
     if cache.post_count(topic_id)? == 0 {
@@ -346,6 +336,28 @@ async fn walk_topic_pages(
         fetched_any = true;
         page += 1;
     }
+}
+
+/// Incrementally fetch a topic into the cache: walk from `start` until 404; if a
+/// resumed walk (start > 1) 404s immediately without fetching or erroring,
+/// re-verify from page 1 — that re-walks a shrunk thread (lowering a now-stale
+/// watermark) or confirms the topic is gone. Returns `(fetched_any,
+/// interrupted)`. Shared by `forum topic` and `refresh-all`.
+async fn fetch_topic_incremental(
+    client: &forum::ForumClient<'_>,
+    cache: &cache::Cache,
+    id: &str,
+    topic_id: i64,
+    start: u32,
+) -> Result<(bool, bool)> {
+    let (mut fetched_any, mut interrupted) =
+        walk_topic_pages(client, cache, id, topic_id, start).await?;
+    if !fetched_any && !interrupted && start > 1 {
+        let (f, i) = walk_topic_pages(client, cache, id, topic_id, 1).await?;
+        fetched_any = f;
+        interrupted = i;
+    }
+    Ok((fetched_any, interrupted))
 }
 
 pub async fn forum_latest(ctx: &ToolCtx<'_>) -> Result<()> {
@@ -446,21 +458,38 @@ pub async fn forum_refresh_all(ctx: &ToolCtx<'_>) -> Result<()> {
         return Ok(());
     }
     let client = forum_client(ctx);
-    let (count, mut total_new) = (ids.len(), 0i64);
+    let count = ids.len();
+    let mut total_new = 0i64;
+    let mut incomplete = 0usize;
     for topic_id in ids {
         let before = cache.post_count(topic_id)?;
         let start = cache.last_page(topic_id)?.max(1);
         let id_str = topic_id.to_string();
-        match walk_topic_pages(&client, &cache, &id_str, topic_id, start).await {
-            Ok(_) => {
+        match fetch_topic_incremental(&client, &cache, &id_str, topic_id, start).await {
+            Ok((_, interrupted)) => {
                 let new = cache.post_count(topic_id)? - before;
                 total_new += new;
-                println!("#{topic_id}: +{new} new");
+                if interrupted {
+                    incomplete += 1;
+                }
+                println!(
+                    "#{topic_id}: +{new} new{}",
+                    if interrupted { " (interrupted)" } else { "" }
+                );
             }
-            Err(e) => eprintln!("#{topic_id}: refresh failed: {e:#}"),
+            Err(e) => {
+                incomplete += 1;
+                eprintln!("#{topic_id}: refresh failed: {e:#}");
+            }
         }
     }
     println!("Refreshed {count} topic(s), {total_new} new post(s).");
+    if incomplete > 0 {
+        // Non-zero exit so automation doesn't treat a partial run as current.
+        bail!(
+            "{incomplete} topic(s) not fully refreshed (rate limit / network) — re-run to continue"
+        );
+    }
     Ok(())
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -369,6 +369,109 @@ fn print_forum(v: &Value, as_json: bool, render: fn(&Value) -> String) -> Result
     Ok(())
 }
 
+/// List locally cached topics (the inventory).
+pub fn forum_topics(ctx: &ToolCtx<'_>) -> Result<()> {
+    if !cache::db_path()?.exists() {
+        if ctx.json_output {
+            println!("[]");
+        } else {
+            println!("No cached topics. Cache one with: inderes forum topic <id>");
+        }
+        return Ok(());
+    }
+    let cache = cache::Cache::open_readonly()?;
+    let topics = cache.list_cached()?;
+    if ctx.json_output {
+        let arr: Vec<Value> = topics
+            .iter()
+            .map(|t| {
+                json!({ "id": t.id, "title": t.title, "posts": t.posts, "synced_at": t.synced_at })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&Value::Array(arr))?);
+    } else if topics.is_empty() {
+        println!("No cached topics. Cache one with: inderes forum topic <id>");
+    } else {
+        for t in &topics {
+            let title = t.title.as_deref().unwrap_or("(untitled)");
+            let synced = t.synced_at.as_deref().unwrap_or("?");
+            println!(
+                "#{:<7} {:>6} posts  synced {synced}  {title}",
+                t.id, t.posts
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Remove a topic from the cache, or the whole cache with `--all`.
+pub fn forum_clear(id: Option<&str>, all: bool, yes: bool) -> Result<()> {
+    if !cache::db_path()?.exists() {
+        println!("No cache to clear.");
+        return Ok(());
+    }
+    let cache = cache::Cache::open()?;
+    match (id, all) {
+        (Some(_), true) => bail!("pass either a topic id or --all, not both"),
+        (None, false) => bail!("specify a topic id, or --all to clear the whole cache"),
+        (Some(id), false) => {
+            let topic_id: i64 = id
+                .parse()
+                .map_err(|_| anyhow!("invalid topic id {id:?}: expected a number"))?;
+            cache.clear_topic(topic_id)?;
+            println!("Cleared topic {topic_id} from the cache.");
+        }
+        (None, true) => {
+            if !yes && !confirm("Clear the entire forum cache?")? {
+                println!("Aborted.");
+                return Ok(());
+            }
+            cache.clear_all()?;
+            println!("Cleared the entire forum cache.");
+        }
+    }
+    Ok(())
+}
+
+/// Refresh every cached topic — pull new posts for each (incremental).
+pub async fn forum_refresh_all(ctx: &ToolCtx<'_>) -> Result<()> {
+    if !cache::db_path()?.exists() {
+        println!("No cached topics to refresh.");
+        return Ok(());
+    }
+    let cache = cache::Cache::open()?;
+    let ids = cache.cached_topic_ids()?;
+    if ids.is_empty() {
+        println!("No cached topics to refresh.");
+        return Ok(());
+    }
+    let client = forum_client(ctx);
+    let (count, mut total_new) = (ids.len(), 0i64);
+    for topic_id in ids {
+        let before = cache.post_count(topic_id)?;
+        let start = cache.last_page(topic_id)?.max(1);
+        let id_str = topic_id.to_string();
+        match walk_topic_pages(&client, &cache, &id_str, topic_id, start).await {
+            Ok(_) => {
+                let new = cache.post_count(topic_id)? - before;
+                total_new += new;
+                println!("#{topic_id}: +{new} new");
+            }
+            Err(e) => eprintln!("#{topic_id}: refresh failed: {e:#}"),
+        }
+    }
+    println!("Refreshed {count} topic(s), {total_new} new post(s).");
+    Ok(())
+}
+
+/// Prompt for y/N confirmation on stderr.
+fn confirm(prompt: &str) -> Result<bool> {
+    eprint!("{prompt} [y/N] ");
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    Ok(matches!(input.trim().to_lowercase().as_str(), "y" | "yes"))
+}
+
 /// Print the path to the local forum cache DB (so you can point sqlite3 /
 /// datasette / duckdb / pandas at it).
 pub fn forum_db_path() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,6 +244,21 @@ enum ForumCmd {
         #[arg(long, default_value_t = 12)]
         periods: u32,
     },
+    /// List locally cached topics (id, post count, last synced).
+    Topics,
+    /// Remove a topic from the cache, or the whole cache with --all.
+    Clear {
+        /// Numeric topic ID to remove.
+        id: Option<String>,
+        /// Clear the entire cache.
+        #[arg(long)]
+        all: bool,
+        /// Skip the confirmation prompt for --all.
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Refresh every cached topic — pull new posts for each.
+    RefreshAll,
     /// Print the path to the local forum cache database.
     DbPath,
 }
@@ -381,6 +396,11 @@ async fn run() -> Result<()> {
             bucket,
             periods,
         }) => commands::forum_activity(&ctx, &id, bucket.as_str(), periods),
+        Command::Forum(ForumCmd::Topics) => commands::forum_topics(&ctx),
+        Command::Forum(ForumCmd::Clear { id, all, yes }) => {
+            commands::forum_clear(id.as_deref(), all, yes)
+        }
+        Command::Forum(ForumCmd::RefreshAll) => commands::forum_refresh_all(&ctx).await,
         Command::Forum(ForumCmd::DbPath) => commands::forum_db_path(),
 
         Command::Call {

--- a/src/skill/hermes.md
+++ b/src/skill/hermes.md
@@ -57,6 +57,9 @@ inderes forum latest              # latest active topics
 inderes forum categories          # category list
 inderes forum query "<SQL>"       # read-only SQL over the cached posts
 inderes forum activity 74         # posting volume over time (momentum)
+inderes forum topics             # list cached topics
+inderes forum refresh-all        # pull new posts for every cached topic
+inderes forum clear <id>         # drop one cached topic (--all to wipe)
 inderes forum db-path             # path to the local SQLite cache
 ```
 

--- a/src/skill/openclaw.md
+++ b/src/skill/openclaw.md
@@ -55,6 +55,9 @@ inderes forum latest              # latest active topics
 inderes forum categories          # category list
 inderes forum query "<SQL>"       # read-only SQL over the cached posts
 inderes forum activity 74         # posting volume over time (momentum)
+inderes forum topics             # list cached topics
+inderes forum refresh-all        # pull new posts for every cached topic
+inderes forum clear <id>         # drop one cached topic (--all to wipe)
 inderes forum db-path             # path to the local SQLite cache
 ```
 

--- a/src/skill/ptrclaw.md
+++ b/src/skill/ptrclaw.md
@@ -52,6 +52,9 @@ inderes forum latest              # latest active topics
 inderes forum categories          # category list
 inderes forum query "<SQL>"       # read-only SQL over the cached posts
 inderes forum activity 74         # posting volume over time (momentum)
+inderes forum topics             # list cached topics
+inderes forum refresh-all        # pull new posts for every cached topic
+inderes forum clear <id>         # drop one cached topic (--all to wipe)
 inderes forum db-path             # path to the local SQLite cache
 ```
 


### PR DESCRIPTION
## What

The operational layer for the local forum cache:

- `forum topics` — list cached topics (id, post count, last synced); `--json` too.
- `forum clear <id>` — drop one topic; `forum clear --all [--yes]` — wipe the cache (confirmation prompt unless `--yes`).
- `forum refresh-all` — incrementally pull new posts for every cached topic (from each watermark), reporting new-posts-per-topic.

## Why

You couldn't previously see or maintain what's cached. This makes a **watchlist** workflow practical — cache several companies' threads, `refresh-all` to keep them current — which is the groundwork for cross-topic momentum ("which thread is heating up across my watchlist").

## Notes

- `cache.rs` adds `list_cached` / `cached_topic_ids` / `clear_topic` / `clear_all` + `CachedTopic`. `refresh-all` reuses the existing incremental `walk_topic_pages`.
- `clear` requires either an id or `--all` (errors if neither / both). `topics`/`clear` are local-only; `refresh-all` hits the network.
- Documented in README ("Managing the cache") + all three skills.

## Testing

- cache: `list_cached` post counts, `clear_topic` / `clear_all`, `cached_topic_ids`.
- `fmt` + `clippy -D warnings` + `cargo test` (165 tests) + markdownlint clean.
- Live: empty list → populate two topics → `topics` → `refresh-all` (+0) → `clear <id>` → `clear --all --yes` → error when neither id nor --all.
