### PR TITLE
feat(forum): cross-topic momentum ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ inderes --json forum topic 74 | jq '.post_stream.posts[].cooked'
 
 ```bash
 inderes forum activity 74             # posting volume over time + a momentum read
+inderes forum momentum                # rank ALL cached topics by momentum
 inderes forum db-path                 # path to the SQLite file
 inderes forum query "SELECT username, COUNT(*) n FROM posts GROUP BY username ORDER BY n DESC LIMIT 10"
 inderes --json forum query "SELECT date(created_at) d, COUNT(*) c FROM posts GROUP BY d ORDER BY d"
@@ -169,7 +170,7 @@ inderes forum clear 74       # drop one topic from the cache
 inderes forum clear --all    # wipe the cache (prompts; --yes to skip)
 ```
 
-`refresh-all` keeps a whole watchlist current in one go, so cross-topic comparisons (e.g. which thread's `activity` is accelerating) stay meaningful.
+`refresh-all` keeps a whole watchlist current in one go, and `forum momentum` then ranks every cached topic by how much it's heating up — the "which company is the crowd suddenly talking about?" view across your watchlist. (An attention signal over cached data; `refresh-all` first for a current picture.)
 
 `forum query` opens the cache **read-only**, so a query can never modify it; table output by default, `--json` emits rows as an array of objects. The `posts` table has typed columns (`id`, `topic_id`, `post_number`, `username`, `created_at`, `cooked`, …), a **`text`** column with the HTML stripped (query this, not `cooked`, for token-cheap reading), and a `raw` column with each post's full JSON (reach any other Discourse field via `json_extract(raw, '$.score')` etc.).
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -329,6 +329,51 @@ impl Cache {
         Ok(rows)
     }
 
+    /// Momentum for a topic, anchored to *now*: the post count in the current
+    /// bucket vs the average per prior bucket over the last `periods` buckets.
+    /// Anchoring to now (rather than the topic's last active bucket) means a
+    /// dormant thread reports a current count of 0 instead of replaying an old
+    /// spike. Returns `(current, baseline_avg)`; `None` if `periods < 2`.
+    pub fn momentum(
+        &self,
+        topic_id: i64,
+        bucket: &str,
+        periods: u32,
+    ) -> Result<Option<(i64, f64)>> {
+        if periods < 2 {
+            return Ok(None);
+        }
+        // `bucket`/`periods` are validated/numeric — safe to interpolate.
+        let (cur_start, win_start) = match bucket {
+            "day" => (
+                "date('now')".to_string(),
+                format!("date('now', '-{} days')", periods - 1),
+            ),
+            "week" => {
+                let mon = "date('now', '-' || ((strftime('%w','now') + 6) % 7) || ' days')";
+                (
+                    mon.to_string(),
+                    format!("date({mon}, '-{} days')", (periods - 1) * 7),
+                )
+            }
+            "month" => (
+                "date('now','start of month')".to_string(),
+                format!("date('now','start of month','-{} months')", periods - 1),
+            ),
+            other => bail!("invalid bucket {other:?}: use day, week, or month"),
+        };
+        let sql = format!(
+            "SELECT
+                (SELECT COUNT(*) FROM posts WHERE topic_id = ?1 AND created_at >= {cur_start}),
+                (SELECT COUNT(*) FROM posts WHERE topic_id = ?1 AND created_at >= {win_start})"
+        );
+        let (current, window_total): (i64, i64) = self
+            .conn
+            .query_row(&sql, [topic_id], |r| Ok((r.get(0)?, r.get(1)?)))?;
+        let baseline = (window_total - current) as f64 / (periods - 1) as f64;
+        Ok(Some((current, baseline)))
+    }
+
     pub fn topic_title(&self, topic_id: i64) -> Result<Option<String>> {
         Ok(self
             .conn
@@ -622,6 +667,39 @@ mod tests {
             "same week must be one bucket, got: {series:?}"
         );
         assert_eq!(series[0].1, 2);
+    }
+
+    #[test]
+    fn momentum_anchors_to_the_current_period() {
+        use time::format_description::well_known::Rfc3339;
+        use time::{Duration, OffsetDateTime};
+        let now = OffsetDateTime::now_utc();
+        let ts = |days: i64| (now - Duration::days(days)).format(&Rfc3339).unwrap();
+        let c = Cache::open_in_memory().unwrap();
+        c.upsert_posts(
+            7,
+            &[
+                json!({"id":1,"post_number":1,"created_at": ts(0), "cooked":"a"}),
+                json!({"id":2,"post_number":2,"created_at": ts(0), "cooked":"b"}),
+                json!({"id":3,"post_number":3,"created_at": ts(1), "cooked":"c"}),
+                json!({"id":4,"post_number":4,"created_at": ts(1), "cooked":"d"}),
+                json!({"id":5,"post_number":5,"created_at": ts(1), "cooked":"e"}),
+                json!({"id":6,"post_number":6,"created_at": ts(30), "cooked":"old"}),
+            ],
+        )
+        .unwrap();
+        // day bucket, 3 periods: current = today (2); window = last 3 days
+        // (today 2 + yesterday 3 = 5, the 30-days-ago post excluded);
+        // baseline = (5 - 2) / 2 = 1.5.
+        let (current, baseline) = c.momentum(7, "day", 3).unwrap().unwrap();
+        assert_eq!(current, 2);
+        assert!((baseline - 1.5).abs() < 1e-9, "baseline {baseline}");
+    }
+
+    #[test]
+    fn momentum_none_below_two_periods() {
+        let c = Cache::open_in_memory().unwrap();
+        assert!(c.momentum(7, "week", 1).unwrap().is_none());
     }
 
     #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -559,6 +559,7 @@ pub fn forum_activity(ctx: &ToolCtx<'_>, id: &str, bucket: &str, periods: u32) -
     if series.is_empty() {
         bail!("no cached posts for topic {id} — run `inderes forum topic {id}` first");
     }
+    let mom = cache.momentum(topic_id, bucket, periods)?;
     if ctx.json_output {
         let mut obj = Map::new();
         obj.insert("bucket".into(), json!(bucket));
@@ -571,27 +572,37 @@ pub fn forum_activity(ctx: &ToolCtx<'_>, id: &str, bucket: &str, periods: u32) -
                     .collect(),
             ),
         );
-        if let Some((latest, avg, ratio)) = momentum(&series) {
+        if let Some((current, baseline)) = mom {
+            let ratio = momentum_ratio(current, baseline);
             obj.insert(
                 "momentum".into(),
                 json!({
-                    "latest": latest,
-                    "baseline_avg": (avg * 100.0).round() / 100.0,
-                    "ratio": (ratio * 100.0).round() / 100.0,
+                    "current": current,
+                    "baseline_avg": (baseline * 100.0).round() / 100.0,
+                    "ratio": ratio_json(ratio),
                 }),
             );
         }
         println!("{}", serde_json::to_string_pretty(&Value::Object(obj))?);
     } else {
         print!("{}", render_activity(topic_id, bucket, &series));
+        if let Some((current, baseline)) = mom {
+            let ratio = momentum_ratio(current, baseline);
+            println!(
+                "\nMomentum: {current} in the current {bucket} vs {baseline:.0} avg — {} ({})",
+                fmt_ratio(ratio),
+                momentum_label(ratio),
+            );
+        }
+        println!("(reflects cached posts; run `inderes forum topic` to refresh)");
     }
     Ok(())
 }
 
 /// Rank cached topics by momentum — which thread is heating up most. For each
-/// cached topic, compute its activity momentum (latest bucket vs the average of
-/// the rest) and sort descending. The cross-topic payoff of the cache: pair it
-/// with `refresh-all` to watch a whole watchlist.
+/// cached topic, compute its current-vs-baseline momentum (anchored to now, so
+/// dormant threads don't replay old spikes) and sort descending. The cross-topic
+/// payoff of the cache: pair with `refresh-all` to watch a whole watchlist.
 pub fn forum_momentum(ctx: &ToolCtx<'_>, bucket: &str, periods: u32) -> Result<()> {
     if !cache::db_path()?.exists() {
         if ctx.json_output {
@@ -602,12 +613,12 @@ pub fn forum_momentum(ctx: &ToolCtx<'_>, bucket: &str, periods: u32) -> Result<(
         return Ok(());
     }
     let cache = cache::Cache::open_readonly()?;
-    // (id, title, latest, baseline_avg, ratio)
+    // (id, title, current, baseline_avg, ratio)
     let mut ranked: Vec<(i64, Option<String>, i64, f64, f64)> = Vec::new();
     for t in cache.list_cached()? {
-        let series = cache.activity(t.id, bucket, periods)?;
-        if let Some((latest, avg, ratio)) = momentum(&series) {
-            ranked.push((t.id, t.title, latest, avg, ratio));
+        if let Some((current, baseline)) = cache.momentum(t.id, bucket, periods)? {
+            let ratio = momentum_ratio(current, baseline);
+            ranked.push((t.id, t.title, current, baseline, ratio));
         }
     }
     ranked.sort_by(|a, b| b.4.total_cmp(&a.4));
@@ -615,25 +626,26 @@ pub fn forum_momentum(ctx: &ToolCtx<'_>, bucket: &str, periods: u32) -> Result<(
     if ctx.json_output {
         let arr: Vec<Value> = ranked
             .iter()
-            .map(|(id, title, latest, avg, ratio)| {
+            .map(|(id, title, current, baseline, ratio)| {
                 json!({
-                    "id": id, "title": title, "latest": latest,
-                    "baseline_avg": (avg * 100.0).round() / 100.0,
-                    "ratio": (ratio * 100.0).round() / 100.0,
+                    "id": id, "title": title, "current": current,
+                    "baseline_avg": (baseline * 100.0).round() / 100.0,
+                    "ratio": ratio_json(*ratio),
                 })
             })
             .collect();
         println!("{}", serde_json::to_string_pretty(&Value::Array(arr))?);
     } else if ranked.is_empty() {
-        println!(
-            "Not enough cached history to rank momentum (need 2+ active {bucket}s per topic)."
-        );
+        println!("Not enough cached history to rank momentum (need --periods 2+).");
     } else {
-        println!("Cross-topic momentum (by {bucket})");
-        println!("{:>6}  {:>6}  {:>5}  topic", "ratio", "latest", "avg");
-        for (id, title, latest, avg, ratio) in &ranked {
+        println!("Cross-topic momentum (by {bucket}, current vs baseline)");
+        println!("{:>6}  {:>7}  {:>5}  topic", "ratio", "current", "avg");
+        for (id, title, current, baseline, ratio) in &ranked {
             let title = title.as_deref().unwrap_or("(untitled)");
-            println!("{ratio:>5.1}x  {latest:>6}  {avg:>5.0}  #{id} {title}");
+            println!(
+                "{:>6}  {current:>7}  {baseline:>5.0}  #{id} {title}",
+                fmt_ratio(*ratio)
+            );
         }
         println!(
             "\n(reflects cached posts; run `inderes forum refresh-all` for a current picture)"
@@ -642,24 +654,49 @@ pub fn forum_momentum(ctx: &ToolCtx<'_>, bucket: &str, periods: u32) -> Result<(
     Ok(())
 }
 
-/// `(latest_count, baseline_avg_of_earlier_periods, ratio)`. `None` with fewer
-/// than two periods (nothing to compare against).
-fn momentum(series: &[(String, i64)]) -> Option<(i64, f64, f64)> {
-    if series.len() < 2 {
-        return None;
-    }
-    let latest = series[series.len() - 1].1;
-    let earlier = &series[..series.len() - 1];
-    let avg = earlier.iter().map(|(_, n)| *n as f64).sum::<f64>() / earlier.len() as f64;
-    let ratio = if avg > 0.0 {
-        latest as f64 / avg
-    } else {
+/// Ratio of current-bucket activity to the prior-bucket baseline. Infinite for a
+/// from-nothing burst (no prior history); zero when dormant.
+fn momentum_ratio(current: i64, baseline: f64) -> f64 {
+    if baseline > 0.0 {
+        current as f64 / baseline
+    } else if current > 0 {
         f64::INFINITY
-    };
-    Some((latest, avg, ratio))
+    } else {
+        0.0
+    }
 }
 
-/// Render the activity timeline as a small bar chart plus a momentum line.
+fn momentum_label(ratio: f64) -> &'static str {
+    if ratio >= 1.5 {
+        "heating up"
+    } else if ratio <= 0.66 {
+        "cooling off"
+    } else {
+        "steady"
+    }
+}
+
+/// Human-readable ratio: "1.7x", or "new" for a from-nothing burst.
+fn fmt_ratio(ratio: f64) -> String {
+    if ratio.is_finite() {
+        format!("{ratio:.1}x")
+    } else {
+        "new".to_string()
+    }
+}
+
+/// JSON ratio: rounded number, or null when non-finite (serde_json can't
+/// represent infinity).
+fn ratio_json(ratio: f64) -> Value {
+    if ratio.is_finite() {
+        json!((ratio * 100.0).round() / 100.0)
+    } else {
+        Value::Null
+    }
+}
+
+/// Render the activity timeline as a small bar chart. The momentum line and
+/// footer are printed by the caller (it uses the current-anchored momentum).
 fn render_activity(topic_id: i64, bucket: &str, series: &[(String, i64)]) -> String {
     let mut out = format!("Activity for topic #{topic_id} (by {bucket})\n");
     let max = series.iter().map(|(_, n)| *n).max().unwrap_or(0).max(1);
@@ -667,19 +704,6 @@ fn render_activity(topic_id: i64, bucket: &str, series: &[(String, i64)]) -> Str
         let bar = "█".repeat(((*n as f64 / max as f64) * 24.0).round() as usize);
         out.push_str(&format!("{p:<10}  {n:>5}  {bar}\n"));
     }
-    if let Some((latest, avg, ratio)) = momentum(series) {
-        let label = if ratio >= 1.5 {
-            "heating up"
-        } else if ratio <= 0.66 {
-            "cooling off"
-        } else {
-            "steady"
-        };
-        out.push_str(&format!(
-            "\nMomentum: {latest} in the latest {bucket} vs {avg:.0} avg — {ratio:.1}x ({label})\n"
-        ));
-    }
-    out.push_str("(reflects cached posts; run `inderes forum topic` to refresh)\n");
     out
 }
 
@@ -1218,33 +1242,39 @@ mod tests {
     // --- momentum / render_activity ---------------------------------------
 
     #[test]
-    fn momentum_compares_latest_to_baseline() {
-        let s = vec![
-            ("w1".to_string(), 10i64),
-            ("w2".to_string(), 10),
-            ("w3".to_string(), 30),
-        ];
-        let (latest, avg, ratio) = momentum(&s).unwrap();
-        assert_eq!(latest, 30);
-        assert_eq!(avg, 10.0);
-        assert_eq!(ratio, 3.0);
+    fn momentum_ratio_handles_baseline_burst_and_dormant() {
+        assert_eq!(momentum_ratio(30, 10.0), 3.0); // heating
+        assert!(momentum_ratio(5, 0.0).is_infinite()); // from-nothing burst
+        assert_eq!(momentum_ratio(0, 4.0), 0.0); // dormant
     }
 
     #[test]
-    fn momentum_is_none_with_one_period() {
-        assert!(momentum(&[("w1".to_string(), 5i64)]).is_none());
+    fn momentum_label_buckets_the_ratio() {
+        assert_eq!(momentum_label(3.0), "heating up");
+        assert_eq!(momentum_label(1.0), "steady");
+        assert_eq!(momentum_label(0.4), "cooling off");
+        assert_eq!(momentum_label(f64::INFINITY), "heating up");
     }
 
     #[test]
-    fn render_activity_shows_bars_and_momentum_label() {
+    fn fmt_ratio_and_ratio_json_handle_infinity() {
+        assert_eq!(fmt_ratio(1.73), "1.7x");
+        assert_eq!(fmt_ratio(f64::INFINITY), "new");
+        assert_eq!(ratio_json(2.0), json!(2.0));
+        assert_eq!(ratio_json(f64::INFINITY), Value::Null);
+    }
+
+    #[test]
+    fn render_activity_shows_bars_only() {
         let s = vec![
             ("2026-W01".to_string(), 10i64),
             ("2026-W02".to_string(), 30),
         ];
         let out = render_activity(7, "week", &s);
         assert!(out.contains("topic #7"));
-        assert!(out.contains("Momentum"));
-        assert!(out.contains("heating up"), "got: {out}");
+        assert!(out.contains("2026-W02"));
+        // Momentum line is printed by the caller, not the chart renderer.
+        assert!(!out.contains("Momentum"), "got: {out}");
     }
 
     // --- render_query_table -----------------------------------------------

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -588,6 +588,60 @@ pub fn forum_activity(ctx: &ToolCtx<'_>, id: &str, bucket: &str, periods: u32) -
     Ok(())
 }
 
+/// Rank cached topics by momentum — which thread is heating up most. For each
+/// cached topic, compute its activity momentum (latest bucket vs the average of
+/// the rest) and sort descending. The cross-topic payoff of the cache: pair it
+/// with `refresh-all` to watch a whole watchlist.
+pub fn forum_momentum(ctx: &ToolCtx<'_>, bucket: &str, periods: u32) -> Result<()> {
+    if !cache::db_path()?.exists() {
+        if ctx.json_output {
+            println!("[]");
+        } else {
+            println!("No cached topics. Cache some with: inderes forum topic <id>");
+        }
+        return Ok(());
+    }
+    let cache = cache::Cache::open_readonly()?;
+    // (id, title, latest, baseline_avg, ratio)
+    let mut ranked: Vec<(i64, Option<String>, i64, f64, f64)> = Vec::new();
+    for t in cache.list_cached()? {
+        let series = cache.activity(t.id, bucket, periods)?;
+        if let Some((latest, avg, ratio)) = momentum(&series) {
+            ranked.push((t.id, t.title, latest, avg, ratio));
+        }
+    }
+    ranked.sort_by(|a, b| b.4.total_cmp(&a.4));
+
+    if ctx.json_output {
+        let arr: Vec<Value> = ranked
+            .iter()
+            .map(|(id, title, latest, avg, ratio)| {
+                json!({
+                    "id": id, "title": title, "latest": latest,
+                    "baseline_avg": (avg * 100.0).round() / 100.0,
+                    "ratio": (ratio * 100.0).round() / 100.0,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&Value::Array(arr))?);
+    } else if ranked.is_empty() {
+        println!(
+            "Not enough cached history to rank momentum (need 2+ active {bucket}s per topic)."
+        );
+    } else {
+        println!("Cross-topic momentum (by {bucket})");
+        println!("{:>6}  {:>6}  {:>5}  topic", "ratio", "latest", "avg");
+        for (id, title, latest, avg, ratio) in &ranked {
+            let title = title.as_deref().unwrap_or("(untitled)");
+            println!("{ratio:>5.1}x  {latest:>6}  {avg:>5.0}  #{id} {title}");
+        }
+        println!(
+            "\n(reflects cached posts; run `inderes forum refresh-all` for a current picture)"
+        );
+    }
+    Ok(())
+}
+
 /// `(latest_count, baseline_avg_of_earlier_periods, ratio)`. `None` with fewer
 /// than two periods (nothing to compare against).
 fn momentum(series: &[(String, i64)]) -> Option<(i64, f64, f64)> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,6 +244,15 @@ enum ForumCmd {
         #[arg(long, default_value_t = 12)]
         periods: u32,
     },
+    /// Rank cached topics by momentum — which thread is heating up most.
+    Momentum {
+        /// Time bucket to group by.
+        #[arg(long, value_enum, default_value_t = Bucket::Week)]
+        bucket: Bucket,
+        /// Number of most-recent buckets to consider per topic.
+        #[arg(long, default_value_t = 12)]
+        periods: u32,
+    },
     /// List locally cached topics (id, post count, last synced).
     Topics,
     /// Remove a topic from the cache, or the whole cache with --all.
@@ -396,6 +405,9 @@ async fn run() -> Result<()> {
             bucket,
             periods,
         }) => commands::forum_activity(&ctx, &id, bucket.as_str(), periods),
+        Command::Forum(ForumCmd::Momentum { bucket, periods }) => {
+            commands::forum_momentum(&ctx, bucket.as_str(), periods)
+        }
         Command::Forum(ForumCmd::Topics) => commands::forum_topics(&ctx),
         Command::Forum(ForumCmd::Clear { id, all, yes }) => {
             commands::forum_clear(id.as_deref(), all, yes)

--- a/src/skill/hermes.md
+++ b/src/skill/hermes.md
@@ -57,6 +57,7 @@ inderes forum latest              # latest active topics
 inderes forum categories          # category list
 inderes forum query "<SQL>"       # read-only SQL over the cached posts
 inderes forum activity 74         # posting volume over time (momentum)
+inderes forum momentum           # rank ALL cached topics by momentum
 inderes forum topics             # list cached topics
 inderes forum refresh-all        # pull new posts for every cached topic
 inderes forum clear <id>         # drop one cached topic (--all to wipe)

--- a/src/skill/openclaw.md
+++ b/src/skill/openclaw.md
@@ -55,6 +55,7 @@ inderes forum latest              # latest active topics
 inderes forum categories          # category list
 inderes forum query "<SQL>"       # read-only SQL over the cached posts
 inderes forum activity 74         # posting volume over time (momentum)
+inderes forum momentum           # rank ALL cached topics by momentum
 inderes forum topics             # list cached topics
 inderes forum refresh-all        # pull new posts for every cached topic
 inderes forum clear <id>         # drop one cached topic (--all to wipe)

--- a/src/skill/ptrclaw.md
+++ b/src/skill/ptrclaw.md
@@ -52,6 +52,7 @@ inderes forum latest              # latest active topics
 inderes forum categories          # category list
 inderes forum query "<SQL>"       # read-only SQL over the cached posts
 inderes forum activity 74         # posting volume over time (momentum)
+inderes forum momentum           # rank ALL cached topics by momentum
 inderes forum topics             # list cached topics
 inderes forum refresh-all        # pull new posts for every cached topic
 inderes forum clear <id>         # drop one cached topic (--all to wipe)


### PR DESCRIPTION
## What

`inderes forum momentum` — ranks **every cached topic** by how much it's heating up, descending. For each topic it computes the same momentum read as `forum activity` (latest bucket vs the average of the rest) and sorts. Table output + `--json`; `--bucket`/`--periods` like `activity`.

This is the cross-topic payoff of the cache: cache a watchlist, `forum refresh-all` to keep it current, then `forum momentum` to see which company the crowd is suddenly talking about.

## Honest framing

An attention/interest signal over **cached** data — noisy (small-sample ratios can rank tiny threads high; the output shows `latest`/`avg` so you can judge), and only as fresh as your last refresh. Output says so. Deterministic; no model.

## Notes

- Pure glue over existing tested pieces: `cache.activity()` + the `momentum()` helper; topics with <2 active buckets are excluded from the ranking.
- Documented in README + all three skills.

## Testing

- `momentum()` math is unit-tested; bucketing is unit-tested.
- `fmt` + `clippy -D warnings` + `cargo test` (165 tests) + markdownlint clean.
- Live: cached 3 topics → ranked table (1.2x / 0.9x / 0.4x) → `--json` → empty-cache message.
