### PR TITLE
feat(forum): read the forum via MCP instead of anonymous Discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,27 +121,25 @@ Every tool-calling subcommand accepts `--json` to emit raw MCP output:
 inderes --json search "Nokia" | jq '.content[0].text'
 ```
 
-### Forum (public, no login)
+### Forum (via the MCP server)
 
-`inderes forum` reads the public [Inderes forum](https://forum.inderes.com) (a Discourse instance) directly over its JSON API. This path is **independent of the MCP server and Keycloak** — it sends no credentials and reads only public content, so it works before (and without) `inderes login`.
+`inderes forum` reads the [Inderes forum](https://forum.inderes.com) through the hosted MCP server's `search-forum-topics` and `get-forum-posts` tools, so it needs `inderes login` like every other subcommand. Use it for community/retail sentiment and discussion, as distinct from analyst research.
 
 ```bash
-inderes forum search "Nokia"      # full-text search across topics and posts
+inderes forum search "Nokia"      # search topic titles (up to 10 matches)
 inderes forum topic 74            # full thread, cached locally (see below)
-inderes forum topic 74 --refresh  # re-fetch from page 1, updating edited posts
-inderes forum latest              # latest active topics
-inderes forum categories          # category list
+inderes forum topic 74 --refresh  # re-fetch from the start, updating edited posts
 ```
 
-`--json` emits the raw Discourse fields (`cooked`, `username`, `created_at`, …), handy for scripting or downstream analysis:
+`--json` emits the structured fields (`cooked`, `username`, `created_at`, plus `url`/`score`/`reply_count` in `raw`), handy for scripting or downstream analysis:
 
 ```bash
 inderes --json forum topic 74 | jq '.post_stream.posts[].cooked'
 ```
 
-> **Read-through cache.** `forum topic <id>` is backed by a local SQLite cache: each call fetches only the posts added since last time, stores them, and serves the whole thread from disk — so re-reads are instant and a long thread is downloaded only once. The first call on a very long thread walks every page; it's resumable, so if it's interrupted or rate-limited, just re-run to continue. `--refresh` re-walks from page 1 to pick up edits to older posts — it upserts rather than wiping, so an interrupted refresh never loses the cached copy. The DB lives at the platform data dir; override with `INDERES_FORUM_DB`. Beyond avoiding re-downloads, the cache is a queryable corpus — common fields land in real columns (`username`, `created_at`, `post_number`, `cooked`) for local analysis, and each post's full raw object is kept too, so `--json` stays faithful. Listings (search/latest/categories) are always live, never cached.
+> **Read-through cache.** `forum topic <id>` is backed by a local SQLite cache: each call fetches only the posts added since last time (resuming from a stored pagination cursor), stores them, and serves the whole thread from disk — so re-reads are instant and a long thread is downloaded only once. The first call on a very long thread walks every page; it's resumable, so if it's interrupted or rate-limited, just re-run to continue. `--refresh` re-walks from the start to pick up edits to older posts — it upserts rather than wiping, so an interrupted refresh never loses the cached copy. The DB lives at the platform data dir; override with `INDERES_FORUM_DB`. Beyond avoiding re-downloads, the cache is a queryable corpus — common fields land in real columns (`username`, `created_at`, `post_number`, `cooked`) for local analysis, and each post's full raw object is kept too, so `--json` stays faithful. `forum search` results are always live, never cached.
 >
-> **Why no login.** The forum is open to all, so authentication isn't required — and isn't currently possible anyway: the forum signs in via the same Keycloak but issues a Discourse session cookie rather than a reusable token, and its third-party User-API-Key feature is disabled. If the forum is ever switched to login-required, anonymous reads return 401/403 and the CLI reports that explicitly instead of failing cryptically. Point the forum base elsewhere with `INDERES_FORUM_URL`.
+> **Titles.** `get-forum-posts` returns posts but no thread title, so a thread opened directly by id lists as `(untitled)`; the title is shown by `forum search`. Post bodies arrive as markdown (not Discourse HTML).
 
 **Analyzing the cache.** Once topics are cached, query them with SQL straight from the CLI, or point your own tools at the database file:
 
@@ -172,7 +170,7 @@ inderes forum clear --all    # wipe the cache (prompts; --yes to skip)
 
 `refresh-all` keeps a whole watchlist current in one go, and `forum momentum` then ranks every cached topic by how much it's heating up — the "which company is the crowd suddenly talking about?" view across your watchlist. (An attention signal over cached data; `refresh-all` first for a current picture.)
 
-`forum query` opens the cache **read-only**, so a query can never modify it; table output by default, `--json` emits rows as an array of objects. The `posts` table has typed columns (`id`, `topic_id`, `post_number`, `username`, `created_at`, `cooked`, …), a **`text`** column with the HTML stripped (query this, not `cooked`, for token-cheap reading), and a `raw` column with each post's full JSON (reach any other Discourse field via `json_extract(raw, '$.score')` etc.).
+`forum query` opens the cache **read-only**, so a query can never modify it; table output by default, `--json` emits rows as an array of objects. The `posts` table has typed columns (`id`, `topic_id`, `post_number`, `username`, `created_at`, `cooked`, …), a **`text`** column with the clean post body, and a `raw` column with each post's full JSON (reach any other field — `url`, `score`, `reply_count` — via `json_extract(raw, '$.score')` etc.).
 
 **Model-judgment analysis (summary, sentiment) is done by the agent, not the CLI.** The CLI just serves clean, sliceable data; an agent does the reasoning with its own model — e.g. pull the latest 40 posts' `text` to be caught up, chunk a long thread by `post_number` ranges to summarize it (map-reduce), or classify a high-`score` slice for bull-vs-bear. The installed skills include these query recipes.
 
@@ -228,7 +226,6 @@ inderes completions powershell | Out-String | Invoke-Expression
 | Variable / flag | Purpose | Default |
 |---|---|---|
 | `--endpoint` / `INDERES_MCP_ENDPOINT` | Override the MCP HTTP endpoint | `https://mcp.inderes.com/` |
-| `INDERES_FORUM_URL` | Override the forum base URL used by `inderes forum` | `https://forum.inderes.com` |
 | `INDERES_FORUM_DB` | Override the SQLite cache path for `inderes forum topic` | platform data dir |
 | `--json` | Emit raw JSON from MCP tool calls | off |
 | `-v` / `-vv` | Increase logging verbosity (`warn` → `info` → `debug`) | `warn` |
@@ -259,7 +256,7 @@ Written atomically (tempfile + rename) so a crash can't leave a half-written fil
 - `src/storage.rs` — atomic-rename JSON file at the platform config dir (0600 on Unix).
 - `src/mcp.rs` — MCP 2025-03-26 Streamable HTTP client, handles both `application/json` and `text/event-stream` responses.
 - `src/commands.rs` — subcommand implementations and output formatting.
-- `src/forum.rs` — read-only Discourse JSON client for the public forum (no auth, independent of MCP).
+- `src/forum.rs` — maps and renders forum data read via the MCP `get-forum-posts` / `search-forum-topics` tools.
 - `src/cache.rs` — local SQLite read-through cache + queryable corpus for forum topic posts.
 - `src/skill/{openclaw,hermes,ptrclaw}.md` — embedded at compile time; `inderes install-skill <host>` writes the right one to disk.
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -84,7 +84,7 @@ impl Cache {
                     id          INTEGER PRIMARY KEY,
                     title       TEXT,
                     posts_count INTEGER,
-                    last_page   INTEGER NOT NULL DEFAULT 0,
+                    cursor      TEXT,
                     synced_at   TEXT
                  );
                  CREATE TABLE IF NOT EXISTS posts (
@@ -118,6 +118,21 @@ impl Cache {
                 .context("adding text column")?;
             self.backfill_text()?;
         }
+
+        // Caches created before the move from Discourse page numbers to MCP
+        // pagination cursors have a `last_page` column but no `cursor`. Add it;
+        // a pre-`cursor` topic just resumes from the start on its next fetch
+        // (an idempotent re-walk), so no backfill is needed.
+        let has_cursor: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('topics') WHERE name = 'cursor'",
+            [],
+            |r| r.get(0),
+        )?;
+        if has_cursor == 0 {
+            self.conn
+                .execute("ALTER TABLE topics ADD COLUMN cursor TEXT", [])
+                .context("adding cursor column")?;
+        }
         Ok(())
     }
 
@@ -145,40 +160,41 @@ impl Cache {
         Ok(())
     }
 
-    /// Highest page already fetched for a topic (0 if the topic is uncached).
-    /// Used as the resume point for incremental fetching.
-    pub fn last_page(&self, topic_id: i64) -> Result<u32> {
-        let v: Option<i64> = self
+    /// The pagination cursor to resume forward fetching from (`None` if the
+    /// topic is uncached or has never been fetched). It marks the end of the
+    /// contiguous run of posts already cached: a fetch resumes with
+    /// `get-forum-posts(after: cursor)` to pull only the posts beyond it.
+    pub fn topic_cursor(&self, topic_id: i64) -> Result<Option<String>> {
+        Ok(self
             .conn
-            .query_row(
-                "SELECT last_page FROM topics WHERE id = ?1",
-                [topic_id],
-                |r| r.get(0),
-            )
-            .optional()?;
-        Ok(v.unwrap_or(0).max(0) as u32)
+            .query_row("SELECT cursor FROM topics WHERE id = ?1", [topic_id], |r| {
+                r.get::<_, Option<String>>(0)
+            })
+            .optional()?
+            .flatten())
     }
 
-    /// Record topic metadata and set the page watermark to the last page
-    /// fetched. The walk calls this with monotonically increasing page numbers,
-    /// so the final call stores the true high-water mark — and a `--refresh`
-    /// (or shrink re-walk) that ends on a lower page correctly lowers it.
+    /// Record topic metadata and advance the resume cursor to the end of the
+    /// posts fetched so far. The walk calls this after each page with that
+    /// page's `endCursor`, so the final call stores the true high-water mark.
+    /// A `--refresh` re-walks from the start and overwrites the cursor as it
+    /// goes, so an interrupted refresh never leaves a stale-but-higher cursor.
     pub fn set_topic_meta(
         &self,
         topic_id: i64,
         title: Option<&str>,
         posts_count: Option<i64>,
-        last_page: u32,
+        cursor: Option<&str>,
     ) -> Result<()> {
         self.conn.execute(
-            "INSERT INTO topics (id, title, posts_count, last_page, synced_at)
+            "INSERT INTO topics (id, title, posts_count, cursor, synced_at)
              VALUES (?1, ?2, ?3, ?4, datetime('now'))
              ON CONFLICT(id) DO UPDATE SET
                 title       = COALESCE(excluded.title, topics.title),
                 posts_count = COALESCE(excluded.posts_count, topics.posts_count),
-                last_page   = excluded.last_page,
+                cursor      = excluded.cursor,
                 synced_at   = excluded.synced_at",
-            params![topic_id, title, posts_count, last_page as i64],
+            params![topic_id, title, posts_count, cursor],
         )?;
         Ok(())
     }
@@ -552,15 +568,16 @@ mod tests {
     }
 
     #[test]
-    fn last_page_defaults_to_zero_then_tracks_watermark() {
+    fn topic_cursor_defaults_to_none_then_tracks_watermark() {
         let c = Cache::open_in_memory().unwrap();
-        assert_eq!(c.last_page(7).unwrap(), 0);
-        c.set_topic_meta(7, Some("Title"), Some(40), 2).unwrap();
-        assert_eq!(c.last_page(7).unwrap(), 2);
-        // The watermark is absolute (a refresh/shrink re-walk that ends lower
-        // must lower it); title is preserved via COALESCE on a None update.
-        c.set_topic_meta(7, None, None, 1).unwrap();
-        assert_eq!(c.last_page(7).unwrap(), 1);
+        assert_eq!(c.topic_cursor(7).unwrap(), None);
+        c.set_topic_meta(7, Some("Title"), Some(40), Some("c2"))
+            .unwrap();
+        assert_eq!(c.topic_cursor(7).unwrap().as_deref(), Some("c2"));
+        // The cursor is overwritten absolutely (a refresh re-walks and resets
+        // it as it goes); title is preserved via COALESCE on a None update.
+        c.set_topic_meta(7, None, None, Some("c1")).unwrap();
+        assert_eq!(c.topic_cursor(7).unwrap().as_deref(), Some("c1"));
         assert_eq!(c.topic_title(7).unwrap().as_deref(), Some("Title"));
     }
 
@@ -748,6 +765,34 @@ mod tests {
     }
 
     #[test]
+    fn migration_adds_cursor_column_to_old_caches() {
+        // A pre-cursor cache has the legacy `last_page` column but no `cursor`.
+        // Opening it must add `cursor` so the resume watermark works; the old
+        // posts/topics are kept (auto-migrate, no wipe).
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("old.db");
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE posts (id INTEGER PRIMARY KEY, topic_id INTEGER NOT NULL,
+                    post_number INTEGER, username TEXT, created_at TEXT, updated_at TEXT,
+                    cooked TEXT, text TEXT, raw TEXT, fetched_at TEXT);
+                 CREATE TABLE topics (id INTEGER PRIMARY KEY, title TEXT, posts_count INTEGER,
+                    last_page INTEGER NOT NULL DEFAULT 0, synced_at TEXT);
+                 INSERT INTO topics (id, title, last_page) VALUES (7, 'Old', 3);",
+            )
+            .unwrap();
+        }
+        let c = Cache::open_at(&path).unwrap();
+        // The legacy topic survives, and the new cursor column reads as NULL
+        // until the next fetch sets it.
+        assert_eq!(c.topic_title(7).unwrap().as_deref(), Some("Old"));
+        assert_eq!(c.topic_cursor(7).unwrap(), None);
+        c.set_topic_meta(7, None, None, Some("c5")).unwrap();
+        assert_eq!(c.topic_cursor(7).unwrap().as_deref(), Some("c5"));
+    }
+
+    #[test]
     fn open_readonly_migrates_old_cache_so_text_is_queryable() {
         // A pre-`text` cache queried via the read-only path must still be
         // upgraded first, or `SELECT text` would fail with "no such column".
@@ -812,10 +857,11 @@ mod tests {
         let c = Cache::open_in_memory().unwrap();
         c.upsert_posts(7, &[post(1, 1, "a", "x"), post(2, 2, "a", "y")])
             .unwrap();
-        c.set_topic_meta(7, Some("Topic Seven"), Some(2), 1)
+        c.set_topic_meta(7, Some("Topic Seven"), Some(2), Some("c1"))
             .unwrap();
         c.upsert_posts(8, &[post(3, 1, "b", "z")]).unwrap();
-        c.set_topic_meta(8, Some("Eight"), Some(1), 1).unwrap();
+        c.set_topic_meta(8, Some("Eight"), Some(1), Some("c1"))
+            .unwrap();
         let list = c.list_cached().unwrap();
         assert_eq!(list.len(), 2);
         let seven = list.iter().find(|t| t.id == 7).unwrap();
@@ -827,9 +873,9 @@ mod tests {
     fn clear_topic_and_clear_all() {
         let c = Cache::open_in_memory().unwrap();
         c.upsert_posts(7, &[post(1, 1, "a", "x")]).unwrap();
-        c.set_topic_meta(7, Some("S"), Some(1), 1).unwrap();
+        c.set_topic_meta(7, Some("S"), Some(1), Some("c1")).unwrap();
         c.upsert_posts(8, &[post(2, 1, "b", "y")]).unwrap();
-        c.set_topic_meta(8, Some("E"), Some(1), 1).unwrap();
+        c.set_topic_meta(8, Some("E"), Some(1), Some("c1")).unwrap();
 
         c.clear_topic(7).unwrap();
         assert_eq!(c.post_count(7).unwrap(), 0);
@@ -844,8 +890,8 @@ mod tests {
     #[test]
     fn cached_topic_ids_lists_all() {
         let c = Cache::open_in_memory().unwrap();
-        c.set_topic_meta(7, None, None, 1).unwrap();
-        c.set_topic_meta(8, None, None, 1).unwrap();
+        c.set_topic_meta(7, None, None, None).unwrap();
+        c.set_topic_meta(8, None, None, None).unwrap();
         assert_eq!(c.cached_topic_ids().unwrap(), vec![7, 8]);
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -226,7 +226,14 @@ impl Cache {
                     continue;
                 };
                 let cooked = p.get("cooked").and_then(Value::as_str);
-                let text = cooked.map(crate::forum::strip_html);
+                // A post may carry a pre-cleaned `text` (MCP markdown bodies,
+                // which must not be HTML-stripped); otherwise derive it from
+                // `cooked` for legacy Discourse HTML.
+                let text = p
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .or_else(|| cooked.map(crate::forum::strip_html));
                 stmt.execute(params![
                     id,
                     topic_id,
@@ -735,6 +742,23 @@ mod tests {
         .unwrap();
         let r = c.query("SELECT text FROM posts WHERE id = 1").unwrap();
         assert_eq!(r.rows[0][0], json!("Hello world"));
+    }
+
+    #[test]
+    fn upsert_keeps_pre_cleaned_text_verbatim() {
+        // A post carrying its own `text` (MCP markdown) must be stored as-is —
+        // not re-derived via strip_html, which would drop `< 10` / `> 5`.
+        let c = Cache::open_in_memory().unwrap();
+        c.upsert_posts(
+            7,
+            &[json!({
+                "id": 1, "post_number": 1,
+                "cooked": "P/E < 10 > 5", "text": "P/E < 10 > 5"
+            })],
+        )
+        .unwrap();
+        let r = c.query("SELECT text FROM posts WHERE id = 1").unwrap();
+        assert_eq!(r.rows[0][0], json!("P/E < 10 > 5"));
     }
 
     #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -102,6 +102,52 @@ impl<'a> ToolCtx<'a> {
         let _ = c.close().await;
         print_result(&result?, self.json_output)
     }
+
+    /// Call a tool and return its raw result envelope, erroring on an
+    /// `isError` result. For callers that need the structured data (to cache or
+    /// re-render) rather than printing it straight through like [`call`].
+    async fn call_raw(&self, tool: &str, args: Value) -> Result<Value> {
+        let mut c = self.client().await?;
+        let result = c.call_tool(tool, args).await;
+        let _ = c.close().await;
+        let result = result?;
+        if let Some(msg) = result_error_text(&result) {
+            bail!("MCP tool {tool} returned an error: {msg}");
+        }
+        Ok(result)
+    }
+}
+
+/// If an MCP result is an error (`isError: true`), return its rendered text for
+/// a diagnostic; otherwise `None`. Keeps the error message off the happy path.
+fn result_error_text(result: &Value) -> Option<String> {
+    if result.get("isError").and_then(Value::as_bool) != Some(true) {
+        return None;
+    }
+    let mut buf = Vec::new();
+    let _ = render_result(result, &mut buf);
+    Some(String::from_utf8_lossy(&buf).trim().to_string())
+}
+
+/// Extract a tool result's structured payload: `structuredContent` if present,
+/// else the first text content item parsed as JSON. Forum fetching and search
+/// both need the typed object, not the human-rendered text.
+fn structured_content(result: &Value) -> Result<Value> {
+    if let Some(sc) = result.get("structuredContent") {
+        return Ok(sc.clone());
+    }
+    let text = result
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|items| {
+            items.iter().find_map(|i| {
+                (i.get("type").and_then(Value::as_str) == Some("text"))
+                    .then(|| i.get("text").and_then(Value::as_str))
+                    .flatten()
+            })
+        })
+        .ok_or_else(|| anyhow!("MCP result had no structuredContent or text content"))?;
+    serde_json::from_str(text).context("parsing MCP text content as JSON")
 }
 
 pub async fn search(ctx: &ToolCtx<'_>, query: &str) -> Result<()> {
@@ -236,24 +282,27 @@ pub async fn documents_read(
     .await
 }
 
-// --- forum (public Discourse, no auth) -------------------------------------
-
-fn forum_client<'a>(ctx: &ToolCtx<'a>) -> forum::ForumClient<'a> {
-    forum::ForumClient::new(ctx.http, &forum::forum_base())
-}
+// --- forum (read via the MCP server, requires login) -----------------------
 
 pub async fn forum_search(ctx: &ToolCtx<'_>, query: &str) -> Result<()> {
-    let v = forum_client(ctx).search(query).await?;
-    print_forum(&v, ctx.json_output, forum::render_search)
+    let result = ctx
+        .call_raw(
+            "search-forum-topics",
+            json!({ "text": query, "order": "relevancy" }),
+        )
+        .await?;
+    let sc = structured_content(&result)?;
+    print_forum(&sc, ctx.json_output, forum::render_forum_search)
 }
 
 /// Read a full topic through the local SQLite cache. On each call it resumes
-/// fetching from the last cached page (re-fetching it to catch newly-appended
-/// posts), walks until a page 404s, upserts as it goes, then renders the whole
-/// thread from the cache. A mid-walk error keeps progress and serves what's
-/// cached, so re-running resumes from the watermark.
+/// fetching from the stored pagination cursor (the end of what's cached),
+/// walking forward page by page via the `get-forum-posts` tool and upserting as
+/// it goes, then renders the whole thread from the cache. A mid-walk error
+/// keeps progress and serves what's cached, so re-running resumes from the
+/// cursor.
 ///
-/// `--refresh` re-walks from page 1 (picking up edits to older posts). It
+/// `--refresh` re-walks from the start (picking up edits to older posts). It
 /// upserts rather than wiping first, so a refresh interrupted by a rate limit
 /// or network error never destroys the previously-complete cached copy.
 pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str, refresh: bool) -> Result<()> {
@@ -261,20 +310,13 @@ pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str, refresh: bool) -> Result<(
         .parse()
         .map_err(|_| anyhow!("invalid topic id {id:?}: expected a number"))?;
     let cache = cache::Cache::open()?;
-    let client = forum_client(ctx);
 
     let start = if refresh {
-        1
+        None
     } else {
-        cache.last_page(topic_id)?.max(1)
+        cache.topic_cursor(topic_id)?
     };
-    let (fetched_any, _) = fetch_topic_incremental(&client, &cache, id, topic_id, start).await?;
-    if !fetched_any && start > 1 && cache.post_count(topic_id)? > 0 {
-        eprintln!(
-            "warning: forum topic {id} returned 404 (deleted or made private); \
-             serving the cached copy."
-        );
-    }
+    fetch_topic(ctx, &cache, topic_id, start).await?;
 
     if cache.post_count(topic_id)? == 0 {
         bail!("forum topic {id} not found or has no posts");
@@ -288,86 +330,63 @@ pub async fn forum_topic(ctx: &ToolCtx<'_>, id: &str, refresh: bool) -> Result<(
     print_forum(&envelope, ctx.json_output, forum::render_topic)
 }
 
-/// Walk a topic's pages from `start` until a page 404s (end of thread),
-/// upserting each page into the cache. Returns `(fetched_any, interrupted)`:
-/// `fetched_any` is whether any page yielded posts, `interrupted` is whether a
-/// transient error (rate limit / network) stopped the walk with cached posts
-/// still available to serve.
-async fn walk_topic_pages(
-    client: &forum::ForumClient<'_>,
+/// Walk a thread forward from `cursor` (`None` = from the start) via the
+/// `get-forum-posts` tool, upserting each page into the cache and advancing the
+/// stored resume cursor. Returns whether the walk was interrupted: a transient
+/// error — or a deleted/private topic — stops the walk and, if posts are
+/// already cached, serves them and warns rather than erroring. The walk stops
+/// when the server reports no further pages (or returns an empty page, i.e.
+/// we're already caught up). Shared by `forum topic` and `refresh-all`.
+async fn fetch_topic(
+    ctx: &ToolCtx<'_>,
     cache: &cache::Cache,
-    id: &str,
     topic_id: i64,
-    start: u32,
-) -> Result<(bool, bool)> {
-    let mut page = start;
-    let mut fetched_any = false;
+    mut cursor: Option<String>,
+) -> Result<bool> {
+    let url = forum::thread_url(topic_id);
+    let mut client = ctx.client().await?;
     loop {
-        let v = match client.topic_page(id, page).await {
-            Ok(Some(v)) => v,
-            Ok(None) => return Ok((fetched_any, false)), // past the end
-            Err(e) => {
-                if cache.post_count(topic_id)? > 0 {
-                    eprintln!(
-                        "warning: forum fetch stopped at page {page} ({e:#}); \
-                         serving cached posts — re-run to resume."
-                    );
-                    return Ok((fetched_any, true));
+        let args = forum::page_request_args(&url, cursor.as_deref());
+        // A transport error or an `isError` result is a fetch failure: serve
+        // cached posts (with a warning) when we have any, else propagate.
+        let fail = match client.call_tool("get-forum-posts", args).await {
+            Ok(result) => match result_error_text(&result) {
+                Some(msg) => Some(msg),
+                None => {
+                    let page = forum::parse_posts_page(&structured_content(&result)?);
+                    if page.posts.is_empty() {
+                        break; // empty thread, or resumed past the last post
+                    }
+                    cache.upsert_posts(topic_id, &page.posts)?;
+                    cache.set_topic_meta(
+                        topic_id,
+                        None,
+                        page.total_posts,
+                        page.next_cursor.as_deref(),
+                    )?;
+                    cursor = page.next_cursor;
+                    if !page.has_next {
+                        break;
+                    }
+                    None
                 }
-                return Err(e);
-            }
+            },
+            Err(e) => Some(format!("{e:#}")),
         };
-        let posts = v
-            .get("post_stream")
-            .and_then(|s| s.get("posts"))
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-        if posts.is_empty() {
-            return Ok((fetched_any, false));
+        if let Some(msg) = fail {
+            let _ = client.close().await;
+            if cache.post_count(topic_id)? > 0 {
+                eprintln!(
+                    "warning: forum fetch for topic {topic_id} stopped ({msg}); \
+                     serving cached posts — re-run to resume."
+                );
+                return Ok(true);
+            }
+            bail!("fetching forum topic {topic_id}: {msg}");
         }
-        cache.upsert_posts(topic_id, &posts)?;
-        cache.set_topic_meta(
-            topic_id,
-            v.get("title").and_then(Value::as_str),
-            v.get("posts_count").and_then(Value::as_i64),
-            page,
-        )?;
-        fetched_any = true;
-        page += 1;
     }
-}
-
-/// Incrementally fetch a topic into the cache: walk from `start` until 404; if a
-/// resumed walk (start > 1) 404s immediately without fetching or erroring,
-/// re-verify from page 1 — that re-walks a shrunk thread (lowering a now-stale
-/// watermark) or confirms the topic is gone. Returns `(fetched_any,
-/// interrupted)`. Shared by `forum topic` and `refresh-all`.
-async fn fetch_topic_incremental(
-    client: &forum::ForumClient<'_>,
-    cache: &cache::Cache,
-    id: &str,
-    topic_id: i64,
-    start: u32,
-) -> Result<(bool, bool)> {
-    let (mut fetched_any, mut interrupted) =
-        walk_topic_pages(client, cache, id, topic_id, start).await?;
-    if !fetched_any && !interrupted && start > 1 {
-        let (f, i) = walk_topic_pages(client, cache, id, topic_id, 1).await?;
-        fetched_any = f;
-        interrupted = i;
-    }
-    Ok((fetched_any, interrupted))
-}
-
-pub async fn forum_latest(ctx: &ToolCtx<'_>) -> Result<()> {
-    let v = forum_client(ctx).latest().await?;
-    print_forum(&v, ctx.json_output, forum::render_latest)
-}
-
-pub async fn forum_categories(ctx: &ToolCtx<'_>) -> Result<()> {
-    let v = forum_client(ctx).categories().await?;
-    print_forum(&v, ctx.json_output, forum::render_categories)
+    let _ = client.close().await;
+    Ok(false)
 }
 
 /// Print a forum response: raw pretty JSON under `--json`, otherwise the
@@ -457,16 +476,14 @@ pub async fn forum_refresh_all(ctx: &ToolCtx<'_>) -> Result<()> {
         println!("No cached topics to refresh.");
         return Ok(());
     }
-    let client = forum_client(ctx);
     let count = ids.len();
     let mut total_new = 0i64;
     let mut incomplete = 0usize;
     for topic_id in ids {
         let before = cache.post_count(topic_id)?;
-        let start = cache.last_page(topic_id)?.max(1);
-        let id_str = topic_id.to_string();
-        match fetch_topic_incremental(&client, &cache, &id_str, topic_id, start).await {
-            Ok((_, interrupted)) => {
+        let start = cache.topic_cursor(topic_id)?;
+        match fetch_topic(ctx, &cache, topic_id, start).await {
+            Ok(interrupted) => {
                 let new = cache.post_count(topic_id)? - before;
                 total_new += new;
                 if interrupted {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -355,7 +355,14 @@ async fn fetch_topic(
                 None => {
                     let page = forum::parse_posts_page(&structured_content(&result)?);
                     if page.posts.is_empty() {
-                        break; // empty thread, or resumed past the last post
+                        // Empty thread, or resumed past the last post. For an
+                        // already-cached topic this is a successful "no new
+                        // posts" refresh — bump synced_at (preserving the
+                        // cursor) so `forum topics` doesn't show a stale time.
+                        if cache.post_count(topic_id)? > 0 {
+                            cache.set_topic_meta(topic_id, None, None, cursor.as_deref())?;
+                        }
+                        break;
                     }
                     cache.upsert_posts(topic_id, &page.posts)?;
                     cache.set_topic_meta(

--- a/src/forum.rs
+++ b/src/forum.rs
@@ -89,17 +89,22 @@ pub fn parse_posts_page(sc: &Value) -> PostsPage {
 }
 
 /// Map one `get-forum-posts` post into the row shape the cache upserts. The
-/// server's markdown `content` goes into `cooked` (where Discourse HTML used to
-/// live) so the existing renderer and `text` derivation keep working; `url`,
+/// server's markdown `content` is stored in **both** `cooked` and `text`: it is
+/// already clean, so it must NOT be HTML-stripped (stripping would treat
+/// ordinary `<`/`>` in bodies like `P/E < 10` as tags and drop text). The
+/// explicit `text` field signals "already clean" to the cache and renderer,
+/// which otherwise derive `text` via `strip_html` for legacy HTML posts. `url`,
 /// `score`, and `reply_count` are carried through so `--json`/SQL over `raw`
 /// stay useful (e.g. ranking by `score`).
 pub fn mcp_post_to_cache(p: &Value) -> Value {
+    let content = p.get("content").and_then(Value::as_str);
     json!({
         "id": p.get("id").and_then(Value::as_i64),
         "post_number": p.get("postNumber").and_then(Value::as_i64),
         "username": p.get("username").and_then(Value::as_str),
         "created_at": p.get("createdAt").and_then(Value::as_str),
-        "cooked": p.get("content").and_then(Value::as_str),
+        "cooked": content,
+        "text": content,
         "url": p.get("url").and_then(Value::as_str),
         "score": p.get("score"),
         "reply_count": p.get("replyCount"),
@@ -144,8 +149,14 @@ pub fn render_topic(v: &Value) -> String {
         let who = p.get("username").and_then(Value::as_str).unwrap_or("?");
         let when = p.get("created_at").and_then(Value::as_str).unwrap_or("");
         out.push_str(&format!("#{n} @{who} ({when}):\n"));
-        let body = p.get("cooked").and_then(Value::as_str).unwrap_or("");
-        out.push_str(&strip_html(body));
+        // Prefer the pre-cleaned `text` (MCP markdown — must not be stripped);
+        // fall back to stripping `cooked` for legacy HTML posts without it.
+        if let Some(text) = p.get("text").and_then(Value::as_str) {
+            out.push_str(text);
+        } else {
+            let body = p.get("cooked").and_then(Value::as_str).unwrap_or("");
+            out.push_str(&strip_html(body));
+        }
         out.push_str("\n\n");
     }
     out
@@ -328,9 +339,14 @@ mod tests {
         assert_eq!(row["post_number"], 1226);
         assert_eq!(row["username"], "Mustathmir");
         assert_eq!(row["created_at"], "2026-06-19T19:42:40.553Z");
-        // Markdown body lands in `cooked` (so the renderer + text column work).
+        // Markdown body lands in both `cooked` and the pre-cleaned `text`
+        // (so it is rendered/stored verbatim, never HTML-stripped).
         assert_eq!(
             row["cooked"],
+            "Nokia ja Acer ovat allekirjoittaneet sopimuksen."
+        );
+        assert_eq!(
+            row["text"],
             "Nokia ja Acer ovat allekirjoittaneet sopimuksen."
         );
         // Extras carried through for --json / SQL over raw.
@@ -445,6 +461,24 @@ mod tests {
         assert!(out.contains("Bullish on margins"));
         assert!(out.contains("#2 @bob"));
         assert!(out.contains("Disagree"));
+    }
+
+    #[test]
+    fn render_topic_does_not_html_strip_markdown_bodies() {
+        // Regression: a markdown body carries a pre-cleaned `text`. It must be
+        // rendered verbatim — `strip_html` would treat `< 10` / `> B` as tags
+        // and silently drop the surrounding text.
+        let v = json!({
+            "id": 5,
+            "title": "Valuation",
+            "post_stream": {"posts": [
+                {"post_number": 1, "username": "alice", "created_at": "2026-01-02",
+                 "cooked": "P/E < 10 and EV/EBITDA > 5",
+                 "text": "P/E < 10 and EV/EBITDA > 5"}
+            ]}
+        });
+        let out = render_topic(&v);
+        assert!(out.contains("P/E < 10 and EV/EBITDA > 5"), "got: {out}");
     }
 
     #[test]

--- a/src/forum.rs
+++ b/src/forum.rs
@@ -1,143 +1,109 @@
-//! Read-only client for the public Discourse JSON API at `forum.inderes.com`.
+//! Forum helpers: mapping and rendering for the Inderes forum, read through the
+//! hosted MCP server's `get-forum-posts` and `search-forum-topics` tools.
 //!
-//! Discourse serves public content as JSON whenever you append `.json` to a
-//! page URL — no authentication required. This is deliberately **separate**
-//! from the MCP/OAuth path: the Keycloak tokens minted for the `inderes-mcp`
-//! client are not valid forum credentials, and Discourse runs its own session
-//! model. We only ever read; we never send credentials here.
+//! Forum reads go over the same authenticated MCP channel as the rest of the
+//! CLI — the server reads `forum.inderes.com` on the user's behalf, so an
+//! `inderes login` (Premium) is required. This module is intentionally
+//! transport-free: `commands.rs` owns the MCP calls and the SQLite cache, while
+//! the pure functions here map a `get-forum-posts` post into the cache's row
+//! shape, render a cached thread, and format `search-forum-topics` results.
 //!
-//! Human output is best-effort (HTML stripped from post bodies). Agents doing
-//! downstream work — e.g. sentiment analysis over posts — should use `--json`
-//! to get the raw Discourse fields (`cooked`, `created_at`, `username`, …).
+//! Post bodies arrive as markdown from the server (not Discourse HTML), so the
+//! cache's clean-text `text` column needs little stripping; `strip_html` is kept
+//! because the cache still runs it and a pre-MCP cache may hold HTML bodies.
 
-use anyhow::{anyhow, bail, Context, Result};
-use serde_json::Value;
+use serde_json::{json, Value};
 
-/// Public Discourse instance. Overridable via `INDERES_FORUM_URL` (used by
-/// tests to point at a mock server; also lets a self-hosted mirror be swapped
-/// in without a recompile).
-pub const DEFAULT_FORUM_URL: &str = "https://forum.inderes.com";
+/// The public forum host. `get-forum-posts` requires a thread URL in the
+/// `/t/<slug>/<id>` shape; the server routes by the trailing id and ignores the
+/// slug, so [`thread_url`] uses a placeholder slug to address a topic by id.
+pub const FORUM_HOST: &str = "https://forum.inderes.com";
 
-/// Resolve the forum base URL from the environment, falling back to the
-/// public Inderes forum.
-pub fn forum_base() -> String {
-    std::env::var("INDERES_FORUM_URL").unwrap_or_else(|_| DEFAULT_FORUM_URL.to_string())
+/// Build a thread URL the `get-forum-posts` tool accepts from a bare topic id.
+/// The slug is a placeholder (`-`): the server routes by the trailing id, so a
+/// real slug is unnecessary and we don't have one when the user types an id.
+pub fn thread_url(topic_id: i64) -> String {
+    format!("{FORUM_HOST}/t/-/{topic_id}")
 }
 
-/// Minimal read-only HTTP client over the Discourse JSON API.
-pub struct ForumClient<'a> {
-    http: &'a reqwest::Client,
-    base: String,
+/// Extract the topic id from a forum thread URL. Search results carry a full
+/// `/t/<slug>/<id>` URL but no bare id; the id is the last path segment that
+/// parses as an integer (topic URLs have no trailing post number).
+pub fn topic_id_from_url(url: &str) -> Option<i64> {
+    url.trim_end_matches('/')
+        .rsplit('/')
+        .find_map(|seg| seg.parse::<i64>().ok())
 }
 
-impl<'a> ForumClient<'a> {
-    pub fn new(http: &'a reqwest::Client, base: &str) -> Self {
-        Self {
-            http,
-            // Normalize so `format!("{base}{path}")` never doubles a slash.
-            base: base.trim_end_matches('/').to_string(),
-        }
-    }
+/// Posts per `get-forum-posts` page. The tool caps `first`/`last` at 50.
+pub const PAGE_SIZE: i64 = 50;
 
-    /// GET a JSON endpoint, treating 404 as an error. Used by the listing
-    /// endpoints (search/latest/categories) where a 404 is genuinely wrong.
-    async fn get_json(&self, path: &str, query: &[(&str, &str)]) -> Result<Value> {
-        self.get_json_opt(path, query)
-            .await?
-            .ok_or_else(|| anyhow!("forum request to {path} returned HTTP 404 Not Found"))
+/// Build the `get-forum-posts` arguments to read one forward page of a thread.
+/// `cursor` is the previous page's `endCursor`; `None` reads from the start.
+/// Forward pagination (`first`/`after`) caches oldest→newest contiguously, so
+/// the stored cursor is always a valid resume point.
+pub fn page_request_args(thread_url: &str, cursor: Option<&str>) -> Value {
+    let mut args = json!({ "threadUrl": thread_url, "first": PAGE_SIZE });
+    if let Some(c) = cursor {
+        args["after"] = json!(c);
     }
+    args
+}
 
-    /// Like `get_json` but returns `Ok(None)` on 404. Topic paging relies on
-    /// this: an out-of-range `?page` 404s, and that is the normal end-of-thread
-    /// signal, not an error.
-    async fn get_json_opt(&self, path: &str, query: &[(&str, &str)]) -> Result<Option<Value>> {
-        let url = format!("{}{}", self.base, path);
-        let resp = self
-            .http
-            .get(&url)
-            .query(query)
-            .header("Accept", "application/json")
-            .send()
-            .await
-            .with_context(|| format!("GET {url}"))?;
-        let status = resp.status();
-        if status == reqwest::StatusCode::NOT_FOUND {
-            return Ok(None);
-        }
-        // A 401/403 on an anonymous read is the signature of the forum being
-        // switched to login-required (Discourse `login_required`). Diagnose it
-        // explicitly rather than emitting a bare status. Name the actual base
-        // (overridable via INDERES_FORUM_URL) and keep the advice generic so a
-        // self-hosted mirror isn't told to "ask Inderes".
-        if matches!(
-            status,
-            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
-        ) {
-            bail!(
-                "{} denied anonymous access (HTTP {status}) — the forum may require login. \
-                 This CLI reads the forum anonymously and cannot authenticate: Discourse only \
-                 accepts a session cookie or a User-API-Key, and the public Inderes forum has \
-                 its User-API-Key feature disabled. Ask the forum administrators to enable it \
-                 for programmatic access.",
-                self.base
-            );
-        }
-        // Body is intentionally kept out of the error: Discourse error pages
-        // can be large HTML, and we never want to splatter that at the user.
-        if !status.is_success() {
-            bail!("forum request to {path} returned HTTP {status}");
-        }
-        let body = resp.text().await.unwrap_or_default();
-        let value = serde_json::from_str(&body).map_err(|e| {
-            // A 200 carrying HTML (CDN / maintenance / login interstitial) is the
-            // common non-JSON case — say so instead of a bare parse error.
-            if body.trim_start().starts_with('<') {
-                anyhow!(
-                    "forum returned a non-JSON response from {path} (HTTP {status}) — likely an \
-                     HTML page (CDN, maintenance, or login interstitial), not the JSON API"
-                )
-            } else {
-                anyhow!("parsing forum JSON response from {path}: {e}")
-            }
-        })?;
-        Ok(Some(value))
-    }
+/// One parsed page of a thread: the cache-ready posts plus the resume signal.
+#[derive(Debug)]
+pub struct PostsPage {
+    pub posts: Vec<Value>,
+    /// `pageInfo.endCursor` — where the next forward page resumes.
+    pub next_cursor: Option<String>,
+    /// `pageInfo.hasNextPage` — whether more posts follow.
+    pub has_next: bool,
+    /// `pageInfo.totalPosts` — the thread's current size, for topic metadata.
+    pub total_posts: Option<i64>,
+}
 
-    /// Full-text search across topics and posts (`/search.json?q=`).
-    pub async fn search(&self, query: &str) -> Result<Value> {
-        self.get_json("/search.json", &[("q", query)]).await
+/// Pull the cache-ready posts and resume signal out of a `get-forum-posts`
+/// `structuredContent` page. Posts are mapped to the cache row shape; the
+/// `pageInfo` drives forward pagination.
+pub fn parse_posts_page(sc: &Value) -> PostsPage {
+    let posts = sc
+        .get("posts")
+        .and_then(Value::as_array)
+        .map(|ps| ps.iter().map(mcp_post_to_cache).collect())
+        .unwrap_or_default();
+    let page_info = sc.get("pageInfo");
+    PostsPage {
+        posts,
+        next_cursor: page_info
+            .and_then(|pi| pi.get("endCursor"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        has_next: page_info
+            .and_then(|pi| pi.get("hasNextPage"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        total_posts: page_info
+            .and_then(|pi| pi.get("totalPosts"))
+            .and_then(Value::as_i64),
     }
+}
 
-    /// Fetch one page of a topic's post stream (`/t/<id>.json`) for the
-    /// read-through cache. `page` is 1-based and ~20 posts per page; page 1
-    /// omits the query param so it matches the bare URL. `Ok(None)` means the
-    /// page is past the end (Discourse 404s out-of-range pages) — the normal
-    /// loop terminator.
-    pub async fn topic_page(&self, id: &str, page: u32) -> Result<Option<Value>> {
-        // Topic ids are integers; reject anything else so a stray slug or path
-        // segment fails clearly instead of producing a confusing request.
-        if id.is_empty() || !id.bytes().all(|b| b.is_ascii_digit()) {
-            bail!("invalid topic id {id:?}: expected a number (the id in a /t/<slug>/<id> URL)");
-        }
-        let path = format!("/t/{id}.json");
-        let page_s = page.to_string();
-        let query: Vec<(&str, &str)> = if page > 1 {
-            vec![("page", page_s.as_str())]
-        } else {
-            Vec::new()
-        };
-        self.get_json_opt(&path, &query).await
-    }
-
-    /// Latest active topics (`/latest.json`).
-    pub async fn latest(&self) -> Result<Value> {
-        self.get_json("/latest.json", &[]).await
-    }
-
-    /// Forum categories (`/categories.json`).
-    pub async fn categories(&self) -> Result<Value> {
-        self.get_json("/categories.json", &[]).await
-    }
+/// Map one `get-forum-posts` post into the row shape the cache upserts. The
+/// server's markdown `content` goes into `cooked` (where Discourse HTML used to
+/// live) so the existing renderer and `text` derivation keep working; `url`,
+/// `score`, and `reply_count` are carried through so `--json`/SQL over `raw`
+/// stay useful (e.g. ranking by `score`).
+pub fn mcp_post_to_cache(p: &Value) -> Value {
+    json!({
+        "id": p.get("id").and_then(Value::as_i64),
+        "post_number": p.get("postNumber").and_then(Value::as_i64),
+        "username": p.get("username").and_then(Value::as_str),
+        "created_at": p.get("createdAt").and_then(Value::as_str),
+        "cooked": p.get("content").and_then(Value::as_str),
+        "url": p.get("url").and_then(Value::as_str),
+        "score": p.get("score"),
+        "reply_count": p.get("replyCount"),
+    })
 }
 
 // --- human-readable rendering ----------------------------------------------
@@ -145,38 +111,10 @@ impl<'a> ForumClient<'a> {
 // Each renderer returns a String so it can be unit-tested without touching
 // stdout. The `--json` path bypasses all of these and prints the raw value.
 
-/// Search results: one line per matched topic, with a stripped blurb from the
-/// best-matching post when Discourse supplies one.
-pub fn render_search(v: &Value) -> String {
-    // Missing `topics` key = unexpected shape (dump raw); present-but-empty =
-    // a genuine no-results.
-    let Some(topics) = v.get("topics").and_then(Value::as_array) else {
-        return fallback_json(v);
-    };
-    if topics.is_empty() {
-        return "No matching topics.\n".to_string();
-    }
-    let posts = v.get("posts").and_then(Value::as_array);
-    let mut out = String::new();
-    for t in topics {
-        let id = t.get("id").and_then(Value::as_i64).unwrap_or(0);
-        let title = t
-            .get("title")
-            .and_then(Value::as_str)
-            .unwrap_or("(untitled)");
-        let count = t.get("posts_count").and_then(Value::as_i64).unwrap_or(0);
-        out.push_str(&format!("#{id}  {title}  ({count} posts)\n"));
-        if let Some(blurb) = posts.and_then(|ps| blurb_for_topic(ps, id)) {
-            out.push_str(&format!("    {}\n", truncate(&strip_html(&blurb), 200)));
-        }
-    }
-    out.push_str("\nOpen a topic with: inderes forum topic <id>\n");
-    out
-}
-
-/// A topic: title followed by every post in the stream, full text (HTML
-/// stripped). Full bodies — not truncated — because the post text is the
-/// payload for downstream analysis.
+/// A topic: title followed by every post in the stream, full body. Full bodies
+/// — not truncated — because the post text is the payload for downstream
+/// analysis. Bodies are markdown; `strip_html` is a no-op on markdown but
+/// cleans up any HTML left from a pre-MCP cache.
 pub fn render_topic(v: &Value) -> String {
     // No post_stream.posts at all = unexpected shape; dump raw JSON instead of
     // masquerading as an empty topic.
@@ -213,57 +151,35 @@ pub fn render_topic(v: &Value) -> String {
     out
 }
 
-/// Latest topics list (`topic_list.topics`).
-pub fn render_latest(v: &Value) -> String {
-    let Some(topics) = v
-        .get("topic_list")
-        .and_then(|l| l.get("topics"))
-        .and_then(Value::as_array)
-    else {
+/// `search-forum-topics` results: one line per matched thread, with the topic
+/// id (parsed from its URL) so the result feeds straight into
+/// `inderes forum topic <id>`.
+pub fn render_forum_search(v: &Value) -> String {
+    // Missing `topics` key = unexpected shape (dump raw); present-but-empty =
+    // a genuine no-results.
+    let Some(topics) = v.get("topics").and_then(Value::as_array) else {
         return fallback_json(v);
     };
     if topics.is_empty() {
-        return "No topics.\n".to_string();
+        return "No matching topics.\n".to_string();
     }
     let mut out = String::new();
     for t in topics {
-        let id = t.get("id").and_then(Value::as_i64).unwrap_or(0);
         let title = t
             .get("title")
             .and_then(Value::as_str)
             .unwrap_or("(untitled)");
-        let count = t.get("posts_count").and_then(Value::as_i64).unwrap_or(0);
-        let views = t.get("views").and_then(Value::as_i64).unwrap_or(0);
-        out.push_str(&format!("#{id}  {title}  ({count} posts, {views} views)\n"));
-    }
-    out.push_str("\nOpen a topic with: inderes forum topic <id>\n");
-    out
-}
-
-/// Categories list (`category_list.categories`).
-pub fn render_categories(v: &Value) -> String {
-    let Some(cats) = v
-        .get("category_list")
-        .and_then(|l| l.get("categories"))
-        .and_then(Value::as_array)
-    else {
-        return fallback_json(v);
-    };
-    if cats.is_empty() {
-        return "No categories.\n".to_string();
-    }
-    let mut out = String::new();
-    for c in cats {
-        let name = c.get("name").and_then(Value::as_str).unwrap_or("(unnamed)");
-        let slug = c.get("slug").and_then(Value::as_str).unwrap_or("");
-        let count = c.get("topic_count").and_then(Value::as_i64).unwrap_or(0);
-        out.push_str(&format!("{name}  [{slug}]  ({count} topics)\n"));
-        if let Some(desc) = c.get("description_text").and_then(Value::as_str) {
-            if !desc.is_empty() {
-                out.push_str(&format!("    {}\n", truncate(desc, 160)));
-            }
+        let count = t.get("postsCount").and_then(Value::as_i64).unwrap_or(0);
+        let id = t
+            .get("url")
+            .and_then(Value::as_str)
+            .and_then(topic_id_from_url);
+        match id {
+            Some(id) => out.push_str(&format!("#{id}  {title}  ({count} posts)\n")),
+            None => out.push_str(&format!("    {title}  ({count} posts)\n")),
         }
     }
+    out.push_str("\nOpen a topic with: inderes forum topic <id>\n");
     out
 }
 
@@ -278,26 +194,11 @@ fn fallback_json(v: &Value) -> String {
 
 // --- pure helpers ----------------------------------------------------------
 
-/// Find the `blurb` of the first search post belonging to `topic_id`.
-fn blurb_for_topic(posts: &[Value], topic_id: i64) -> Option<String> {
-    posts.iter().find_map(|p| {
-        let same = p.get("topic_id").and_then(Value::as_i64) == Some(topic_id);
-        if same {
-            p.get("blurb")
-                .and_then(Value::as_str)
-                .filter(|b| !b.is_empty())
-                .map(str::to_string)
-        } else {
-            None
-        }
-    })
-}
-
 /// Best-effort HTML → text for terminal reading: map block boundaries to
 /// newlines (so multi-paragraph posts stay readable), drop remaining tags,
 /// collapse intra-line whitespace while keeping line breaks, then decode the
 /// handful of entities Discourse emits. Not a parser. Also used by the cache to
-/// populate the clean-text `text` column.
+/// populate the clean-text `text` column. A no-op on plain markdown.
 pub(crate) fn strip_html(s: &str) -> String {
     let with_breaks = s
         .replace("</p>", "\n\n")
@@ -346,24 +247,12 @@ fn decode_entities(s: &str) -> String {
         .replace("&amp;", "&")
 }
 
-/// Truncate to at most `max` chars (char-safe), appending `…` when cut.
-fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        return s.to_string();
-    }
-    let mut out: String = s.chars().take(max).collect();
-    out.push('…');
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
-    use wiremock::matchers::{method, path, query_param, query_param_is_missing};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    // --- strip_html / decode_entities / truncate ---------------------------
+    // --- strip_html / decode_entities --------------------------------------
 
     #[test]
     fn strip_html_collapses_intra_line_whitespace_but_keeps_paragraphs() {
@@ -392,73 +281,144 @@ mod tests {
     }
 
     #[test]
-    fn strip_html_on_plain_text_is_identity_modulo_whitespace() {
-        assert_eq!(strip_html("just text"), "just text");
+    fn strip_html_on_markdown_is_identity_modulo_whitespace() {
+        // Server bodies are markdown: links/images pass through untouched.
+        let md = "See [ip fray](https://ipfray.com) for **details**";
+        assert_eq!(strip_html(md), md);
+    }
+
+    // --- thread_url / topic_id_from_url ------------------------------------
+
+    #[test]
+    fn thread_url_addresses_topic_by_id_with_placeholder_slug() {
+        assert_eq!(thread_url(73687), "https://forum.inderes.com/t/-/73687");
     }
 
     #[test]
-    fn truncate_leaves_short_strings_untouched() {
-        assert_eq!(truncate("short", 10), "short");
+    fn topic_id_from_url_takes_the_trailing_numeric_segment() {
+        assert_eq!(
+            topic_id_from_url("https://forum.inderes.com/t/nokia-sijoituskohteena-osa-4/73687"),
+            Some(73687)
+        );
+        // Trailing slash is tolerated.
+        assert_eq!(
+            topic_id_from_url("https://forum.inderes.com/t/x/74/"),
+            Some(74)
+        );
+        // No numeric segment → None (renders without an id rather than wrong).
+        assert_eq!(topic_id_from_url("https://forum.inderes.com/about"), None);
+    }
+
+    // --- mcp_post_to_cache -------------------------------------------------
+
+    #[test]
+    fn mcp_post_to_cache_maps_server_fields_to_cache_columns() {
+        let mcp = json!({
+            "id": 1159826,
+            "url": "https://forum.inderes.com/t/x/73687/1226",
+            "username": "Mustathmir",
+            "createdAt": "2026-06-19T19:42:40.553Z",
+            "content": "Nokia ja Acer ovat allekirjoittaneet sopimuksen.",
+            "postNumber": 1226,
+            "replyCount": 0,
+            "score": 12.5
+        });
+        let row = mcp_post_to_cache(&mcp);
+        assert_eq!(row["id"], 1159826);
+        assert_eq!(row["post_number"], 1226);
+        assert_eq!(row["username"], "Mustathmir");
+        assert_eq!(row["created_at"], "2026-06-19T19:42:40.553Z");
+        // Markdown body lands in `cooked` (so the renderer + text column work).
+        assert_eq!(
+            row["cooked"],
+            "Nokia ja Acer ovat allekirjoittaneet sopimuksen."
+        );
+        // Extras carried through for --json / SQL over raw.
+        assert_eq!(row["url"], "https://forum.inderes.com/t/x/73687/1226");
+        assert_eq!(row["score"], 12.5);
+        assert_eq!(row["reply_count"], 0);
+    }
+
+    // --- pagination helpers ------------------------------------------------
+
+    #[test]
+    fn page_request_args_omits_after_on_the_first_page() {
+        let a = page_request_args("https://forum.inderes.com/t/-/74", None);
+        assert_eq!(a["threadUrl"], "https://forum.inderes.com/t/-/74");
+        assert_eq!(a["first"], 50);
+        assert!(
+            a.get("after").is_none(),
+            "first page must not send a cursor"
+        );
     }
 
     #[test]
-    fn truncate_cuts_and_appends_ellipsis() {
-        let out = truncate("abcdefghij", 5);
-        assert_eq!(out, "abcde…");
+    fn page_request_args_resumes_from_cursor() {
+        let a = page_request_args("https://forum.inderes.com/t/-/74", Some("c42"));
+        assert_eq!(a["after"], "c42");
+        assert_eq!(a["first"], 50);
     }
 
     #[test]
-    fn truncate_is_char_safe_on_multibyte() {
-        // Five multibyte chars, limit 3 — must not panic on a byte boundary.
-        let out = truncate("äöåüö", 3);
-        assert_eq!(out, "äöå…");
+    fn parse_posts_page_maps_posts_and_reads_pageinfo() {
+        let sc = json!({
+            "posts": [
+                {"id": 1, "postNumber": 1, "username": "a", "createdAt": "2026-01-01",
+                 "content": "first", "url": "u1", "replyCount": 0, "score": 0},
+                {"id": 2, "postNumber": 2, "username": "b", "createdAt": "2026-01-02",
+                 "content": "second", "url": "u2", "replyCount": 1, "score": 3}
+            ],
+            "pageInfo": {"endCursor": "2", "hasNextPage": true, "totalPosts": 1176}
+        });
+        let page = parse_posts_page(&sc);
+        assert_eq!(page.posts.len(), 2);
+        assert_eq!(page.posts[0]["post_number"], 1);
+        assert_eq!(page.posts[0]["cooked"], "first");
+        assert_eq!(page.next_cursor.as_deref(), Some("2"));
+        assert!(page.has_next);
+        assert_eq!(page.total_posts, Some(1176));
     }
 
     #[test]
-    fn blurb_for_topic_matches_by_topic_id() {
-        let posts = vec![
-            json!({"topic_id": 1, "blurb": "first"}),
-            json!({"topic_id": 2, "blurb": "second"}),
-        ];
-        assert_eq!(blurb_for_topic(&posts, 2).as_deref(), Some("second"));
-        assert_eq!(blurb_for_topic(&posts, 99), None);
+    fn parse_posts_page_handles_a_terminal_page() {
+        // Last page: no more posts to follow.
+        let sc = json!({"posts": [], "pageInfo": {"endCursor": "9", "hasNextPage": false}});
+        let page = parse_posts_page(&sc);
+        assert!(page.posts.is_empty());
+        assert!(!page.has_next);
+        assert_eq!(page.next_cursor.as_deref(), Some("9"));
+        assert_eq!(page.total_posts, None);
     }
 
     // --- renderers ---------------------------------------------------------
 
     #[test]
-    fn render_search_lists_topics_with_blurbs() {
-        let v = json!({
-            "topics": [{"id": 42, "title": "Revenue beat", "posts_count": 7}],
-            "posts": [{"topic_id": 42, "blurb": "<b>Strong</b> quarter"}]
-        });
-        let out = render_search(&v);
-        assert!(out.contains("#42"));
-        assert!(out.contains("Revenue beat"));
-        assert!(out.contains("7 posts"));
-        // Blurb HTML is stripped.
-        assert!(out.contains("Strong quarter"));
-        assert!(!out.contains("<b>"));
+    fn render_forum_search_lists_topics_with_ids_from_url() {
+        let v = json!({"topics": [
+            {"title": "Nokia sijoituskohteena (Osa 4)", "postsCount": 1176,
+             "url": "https://forum.inderes.com/t/nokia-sijoituskohteena-osa-4/73687"}
+        ]});
+        let out = render_forum_search(&v);
+        assert!(out.contains("#73687"), "got: {out}");
+        assert!(out.contains("Nokia sijoituskohteena (Osa 4)"));
+        assert!(out.contains("1176 posts"));
         assert!(out.contains("inderes forum topic"));
     }
 
     #[test]
-    fn render_search_empty_topics_is_a_genuine_no_result() {
-        // `topics` present but empty = no matches.
+    fn render_forum_search_empty_topics_is_a_genuine_no_result() {
         assert_eq!(
-            render_search(&json!({"topics": []})),
+            render_forum_search(&json!({"topics": []})),
             "No matching topics.\n"
         );
     }
 
     #[test]
     fn render_unrecognized_shape_dumps_raw_json_not_a_fake_empty() {
-        // `topics`/`topic_list`/`category_list`/`post_stream` missing entirely =
-        // unexpected shape; surface it instead of pretending it's empty.
+        // `topics`/`post_stream` missing entirely = unexpected shape; surface it
+        // instead of pretending it's empty.
         for out in [
-            render_search(&json!({"unexpected": 1})),
-            render_latest(&json!({"unexpected": 1})),
-            render_categories(&json!({"unexpected": 1})),
+            render_forum_search(&json!({"unexpected": 1})),
             render_topic(&json!({"unexpected": 1})),
         ] {
             assert!(out.contains("unrecognized"), "got: {out}");
@@ -473,9 +433,9 @@ mod tests {
             "title": "Outlook",
             "post_stream": {"posts": [
                 {"post_number": 1, "username": "alice", "created_at": "2026-01-02",
-                 "cooked": "<p>Bullish on margins</p>"},
+                 "cooked": "Bullish on margins"},
                 {"post_number": 2, "username": "bob", "created_at": "2026-01-03",
-                 "cooked": "<p>Disagree</p>"}
+                 "cooked": "Disagree"}
             ]}
         });
         let out = render_topic(&v);
@@ -485,7 +445,6 @@ mod tests {
         assert!(out.contains("Bullish on margins"));
         assert!(out.contains("#2 @bob"));
         assert!(out.contains("Disagree"));
-        assert!(!out.contains("<p>"));
     }
 
     #[test]
@@ -493,194 +452,5 @@ mod tests {
         let out = render_topic(&json!({"title": "Empty", "post_stream": {"posts": []}}));
         assert!(out.contains("Empty"));
         assert!(out.contains("(no posts)"));
-    }
-
-    #[test]
-    fn render_latest_lists_topics() {
-        let v = json!({"topic_list": {"topics": [
-            {"id": 9, "title": "Daily thread", "posts_count": 120, "views": 4000}
-        ]}});
-        let out = render_latest(&v);
-        assert!(out.contains("#9"));
-        assert!(out.contains("Daily thread"));
-        assert!(out.contains("120 posts"));
-        assert!(out.contains("4000 views"));
-    }
-
-    #[test]
-    fn render_categories_lists_names_and_descriptions() {
-        let v = json!({"category_list": {"categories": [
-            {"name": "Osakkeet", "slug": "osakkeet", "topic_count": 800,
-             "description_text": "Keskustelua osakkeista"}
-        ]}});
-        let out = render_categories(&v);
-        assert!(out.contains("Osakkeet"));
-        assert!(out.contains("[osakkeet]"));
-        assert!(out.contains("800 topics"));
-        assert!(out.contains("Keskustelua osakkeista"));
-    }
-
-    // --- ForumClient (wiremock) -------------------------------------------
-
-    #[tokio::test]
-    async fn search_hits_search_endpoint_with_query() {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/search.json"))
-            .and(query_param("q", "nokia"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "topics": [{"id": 1, "title": "Nokia", "posts_count": 3}],
-                "posts": []
-            })))
-            .expect(1)
-            .mount(&server)
-            .await;
-
-        let http = reqwest::Client::new();
-        let client = ForumClient::new(&http, &server.uri());
-        let v = client.search("nokia").await.unwrap();
-        assert_eq!(v["topics"][0]["title"], "Nokia");
-    }
-
-    #[tokio::test]
-    async fn topic_page_1_omits_the_page_query_param() {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/t/123.json"))
-            .and(query_param_is_missing("page"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "id": 123, "title": "Topic", "post_stream": {"posts": []}
-            })))
-            .expect(1)
-            .mount(&server)
-            .await;
-
-        let http = reqwest::Client::new();
-        let client = ForumClient::new(&http, &server.uri());
-        let v = client
-            .topic_page("123", 1)
-            .await
-            .unwrap()
-            .expect("page present");
-        assert_eq!(v["id"], 123);
-    }
-
-    #[tokio::test]
-    async fn topic_page_n_sends_the_page_query_param() {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/t/123.json"))
-            .and(query_param("page", "2"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "id": 123, "title": "T",
-                "post_stream": {"posts": [
-                    {"post_number": 21, "username": "u", "cooked": "<p>x</p>"}
-                ]}
-            })))
-            .expect(1)
-            .mount(&server)
-            .await;
-
-        let http = reqwest::Client::new();
-        let client = ForumClient::new(&http, &server.uri());
-        let v = client
-            .topic_page("123", 2)
-            .await
-            .unwrap()
-            .expect("page present");
-        assert_eq!(v["post_stream"]["posts"][0]["post_number"], 21);
-    }
-
-    #[tokio::test]
-    async fn topic_page_404_signals_end_of_thread() {
-        // An out-of-range page 404s; that is the loop terminator, not an error.
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/t/404.json"))
-            .respond_with(ResponseTemplate::new(404).set_body_string("<html>nope</html>"))
-            .mount(&server)
-            .await;
-
-        let http = reqwest::Client::new();
-        let client = ForumClient::new(&http, &server.uri());
-        assert!(client.topic_page("404", 1).await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn server_error_is_an_error_without_body() {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/latest.json"))
-            .respond_with(ResponseTemplate::new(500).set_body_string("<html>big error page</html>"))
-            .mount(&server)
-            .await;
-
-        let http = reqwest::Client::new();
-        let client = ForumClient::new(&http, &server.uri());
-        let err = client.latest().await.unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains("500"), "got: {msg}");
-        // The HTML body must not leak into the error.
-        assert!(!msg.contains("big error page"), "got: {msg}");
-    }
-
-    #[tokio::test]
-    async fn topic_rejects_non_numeric_id() {
-        // No network needed — validation happens before the request.
-        let http = reqwest::Client::new();
-        let client = ForumClient::new(&http, "https://example.com");
-        let err = client.topic_page("../latest", 1).await.unwrap_err();
-        assert!(
-            format!("{err:#}").contains("invalid topic id"),
-            "got: {err:#}"
-        );
-    }
-
-    #[tokio::test]
-    async fn html_200_is_reported_as_non_json() {
-        // A 200 carrying an HTML interstitial must produce a clear diagnostic,
-        // not a bare serde parse error, and must not leak the HTML body.
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/latest.json"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_string("<html><body>DO_NOT_LEAK_42</body></html>"),
-            )
-            .mount(&server)
-            .await;
-
-        let http = reqwest::Client::new();
-        let client = ForumClient::new(&http, &server.uri());
-        let err = client.latest().await.unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains("non-JSON"), "got: {msg}");
-        assert!(!msg.contains("DO_NOT_LEAK_42"), "got: {msg}");
-    }
-
-    #[tokio::test]
-    async fn forbidden_is_diagnosed_as_login_required() {
-        // The signature of the forum being flipped to login-required: an
-        // anonymous read returns 403. We must explain it, not just echo 403.
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/latest.json"))
-            .respond_with(ResponseTemplate::new(403).set_body_string(r#"{"errors":["nope"]}"#))
-            .mount(&server)
-            .await;
-
-        let http = reqwest::Client::new();
-        let client = ForumClient::new(&http, &server.uri());
-        let err = client.latest().await.unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains("require login"), "got: {msg}");
-        assert!(msg.contains("User-API-Key"), "got: {msg}");
-    }
-
-    #[test]
-    fn new_trims_trailing_slash_from_base() {
-        let http = reqwest::Client::new();
-        let client = ForumClient::new(&http, "https://forum.example.com/");
-        assert_eq!(client.base, "https://forum.example.com");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,8 @@ enum Command {
     #[command(subcommand)]
     Documents(DocumentsCmd),
 
-    /// Read the public Inderes forum (forum.inderes.com). No login required.
+    /// Read the Inderes forum (forum.inderes.com) via the MCP server. Requires
+    /// `inderes login`.
     #[command(subcommand)]
     Forum(ForumCmd),
 
@@ -209,7 +210,7 @@ enum ContentCmd {
 
 #[derive(Debug, Subcommand)]
 enum ForumCmd {
-    /// Full-text search across forum topics and posts.
+    /// Search forum topic titles (up to 10 matching threads).
     Search {
         /// Free-text query.
         query: String,
@@ -219,15 +220,11 @@ enum ForumCmd {
     Topic {
         /// Numeric topic ID (the number in a /t/<slug>/<id> URL).
         id: String,
-        /// Re-fetch the whole thread from page 1, replacing the cached copy
+        /// Re-fetch the whole thread from the start, replacing the cached copy
         /// (picks up edited or deleted posts).
         #[arg(long)]
         refresh: bool,
     },
-    /// List the latest active topics.
-    Latest,
-    /// List forum categories.
-    Categories,
     /// Run a read-only SQL query against the local forum cache.
     Query {
         /// SQL to run (e.g. "SELECT username, COUNT(*) FROM posts GROUP BY username").
@@ -397,8 +394,6 @@ async fn run() -> Result<()> {
         Command::Forum(ForumCmd::Topic { id, refresh }) => {
             commands::forum_topic(&ctx, &id, refresh).await
         }
-        Command::Forum(ForumCmd::Latest) => commands::forum_latest(&ctx).await,
-        Command::Forum(ForumCmd::Categories) => commands::forum_categories(&ctx).await,
         Command::Forum(ForumCmd::Query { sql }) => commands::forum_query(&ctx, &sql),
         Command::Forum(ForumCmd::Activity {
             id,

--- a/src/skill/hermes.md
+++ b/src/skill/hermes.md
@@ -45,16 +45,14 @@ Then call a friendly subcommand:
 
 Append `--json` on any subcommand to get raw JSON (easier to post-process).
 
-## Forum (public, no login)
+## Forum (via the MCP server, requires login)
 
-`inderes forum` reads the public Inderes forum (forum.inderes.com) directly — **no `inderes login` required**; it sends no credentials. Use it for community/retail sentiment and discussion, as distinct from analyst research.
+`inderes forum` reads the Inderes forum (forum.inderes.com) through the hosted MCP server — `inderes login` (Premium) is required, like every other subcommand. Use it for community/retail sentiment and discussion, as distinct from analyst research.
 
 ```bash
-inderes forum search "Nokia"      # full-text search across topics and posts
+inderes forum search "Nokia"      # search topic titles (up to 10 matches)
 inderes forum topic 74            # full thread (read-through SQLite cache)
-inderes forum topic 74 --refresh  # re-fetch from page 1, updating edits
-inderes forum latest              # latest active topics
-inderes forum categories          # category list
+inderes forum topic 74 --refresh  # re-fetch from the start, updating edits
 inderes forum query "<SQL>"       # read-only SQL over the cached posts
 inderes forum activity 74         # posting volume over time (momentum)
 inderes forum momentum           # rank ALL cached topics by momentum
@@ -64,11 +62,11 @@ inderes forum clear <id>         # drop one cached topic (--all to wipe)
 inderes forum db-path             # path to the local SQLite cache
 ```
 
-Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`. Cached posts are queryable with `inderes forum query "<SQL>"` (read-only) — e.g. most active users on a stock, or posting volume over time.
+`forum search` wraps the `search-forum-topics` MCP tool (title match, max 10) and prints each thread's id so it feeds straight into `forum topic <id>`. `forum topic` pulls the **whole** thread via the `get-forum-posts` tool into a local SQLite read-through cache: only new posts are fetched each call (resumable — re-run if interrupted), and the full thread is served from disk. Add `--json` for the raw fields (`cooked` = markdown body, `username`, `created_at`, plus `url`/`score`/`reply_count` in `raw`). A thread opened by bare id shows as `(untitled)` — the server returns no thread title; the title appears in `forum search` results. Cached posts are queryable with `inderes forum query "<SQL>"` (read-only) — e.g. most active users on a stock, or posting volume over time.
 
 ## Analyzing cached threads (you reason, the CLI only serves data)
 
-The cache has a clean-text `text` column (HTML stripped) — query `text`, not `cooked`, to save tokens. Cache a topic first with `inderes forum topic <id>`, then:
+The cache has a clean-text `text` column — query `text` for post bodies. Cache a topic first with `inderes forum topic <id>`, then:
 
 - **Catch me up** (recent posts): `inderes --json forum query "SELECT post_number, username, date(created_at) d, text FROM posts WHERE topic_id=74 ORDER BY post_number DESC LIMIT 40"` → summarize the result yourself.
 - **Summarize a long thread** (map-reduce — a big thread won't fit in context): pull it in chunks, summarize each, then combine. Get the size with `SELECT MAX(post_number) FROM posts WHERE topic_id=74`, then `... WHERE topic_id=74 AND post_number BETWEEN 1 AND 500 ORDER BY post_number` (repeat for 501–1000, …).

--- a/src/skill/openclaw.md
+++ b/src/skill/openclaw.md
@@ -43,16 +43,14 @@ Then call one of the friendly subcommands, or drop down to `inderes call <tool>`
 
 Pass `--json` to any of the above to get raw JSON (useful when you need to extract structured data).
 
-## Forum (public, no login)
+## Forum (via the MCP server, requires login)
 
-`inderes forum` reads the public Inderes forum (forum.inderes.com) directly — **no `inderes login` required**; it sends no credentials. Use it for community/retail sentiment and discussion, as distinct from analyst research.
+`inderes forum` reads the Inderes forum (forum.inderes.com) through the hosted MCP server — `inderes login` (Premium) is required, like every other subcommand. Use it for community/retail sentiment and discussion, as distinct from analyst research.
 
 ```bash
-inderes forum search "Nokia"      # full-text search across topics and posts
+inderes forum search "Nokia"      # search topic titles (up to 10 matches)
 inderes forum topic 74            # full thread (read-through SQLite cache)
-inderes forum topic 74 --refresh  # re-fetch from page 1, updating edits
-inderes forum latest              # latest active topics
-inderes forum categories          # category list
+inderes forum topic 74 --refresh  # re-fetch from the start, updating edits
 inderes forum query "<SQL>"       # read-only SQL over the cached posts
 inderes forum activity 74         # posting volume over time (momentum)
 inderes forum momentum           # rank ALL cached topics by momentum
@@ -62,11 +60,11 @@ inderes forum clear <id>         # drop one cached topic (--all to wipe)
 inderes forum db-path             # path to the local SQLite cache
 ```
 
-Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`. Cached posts are queryable with `inderes forum query "<SQL>"` (read-only) — e.g. most active users on a stock, or posting volume over time.
+`forum search` wraps the `search-forum-topics` MCP tool (title match, max 10) and prints each thread's id so it feeds straight into `forum topic <id>`. `forum topic` pulls the **whole** thread via the `get-forum-posts` tool into a local SQLite read-through cache: only new posts are fetched each call (resumable — re-run if interrupted), and the full thread is served from disk. Add `--json` for the raw fields (`cooked` = markdown body, `username`, `created_at`, plus `url`/`score`/`reply_count` in `raw`). A thread opened by bare id shows as `(untitled)` — the server returns no thread title; the title appears in `forum search` results. Cached posts are queryable with `inderes forum query "<SQL>"` (read-only) — e.g. most active users on a stock, or posting volume over time.
 
 ## Analyzing cached threads (you reason, the CLI only serves data)
 
-The cache has a clean-text `text` column (HTML stripped) — query `text`, not `cooked`, to save tokens. Cache a topic first with `inderes forum topic <id>`, then:
+The cache has a clean-text `text` column — query `text` for post bodies. Cache a topic first with `inderes forum topic <id>`, then:
 
 - **Catch me up** (recent posts): `inderes --json forum query "SELECT post_number, username, date(created_at) d, text FROM posts WHERE topic_id=74 ORDER BY post_number DESC LIMIT 40"` → summarize the result yourself.
 - **Summarize a long thread** (map-reduce — a big thread won't fit in context): pull it in chunks, summarize each, then combine. Get the size with `SELECT MAX(post_number) FROM posts WHERE topic_id=74`, then `... WHERE topic_id=74 AND post_number BETWEEN 1 AND 500 ORDER BY post_number` (repeat for 501–1000, …).

--- a/src/skill/ptrclaw.md
+++ b/src/skill/ptrclaw.md
@@ -40,16 +40,14 @@ Then call a friendly subcommand:
 
 Append `--json` on any subcommand to get raw JSON (easier to post-process).
 
-## Forum (public, no login)
+## Forum (via the MCP server, requires login)
 
-`inderes forum` reads the public Inderes forum (forum.inderes.com) directly — **no `inderes login` required**; it sends no credentials. Use it for community/retail sentiment and discussion, as distinct from analyst research.
+`inderes forum` reads the Inderes forum (forum.inderes.com) through the hosted MCP server — `inderes login` (Premium) is required, like every other subcommand. Use it for community/retail sentiment and discussion, as distinct from analyst research.
 
 ```bash
-inderes forum search "Nokia"      # full-text search across topics and posts
+inderes forum search "Nokia"      # search topic titles (up to 10 matches)
 inderes forum topic 74            # full thread (read-through SQLite cache)
-inderes forum topic 74 --refresh  # re-fetch from page 1, updating edits
-inderes forum latest              # latest active topics
-inderes forum categories          # category list
+inderes forum topic 74 --refresh  # re-fetch from the start, updating edits
 inderes forum query "<SQL>"       # read-only SQL over the cached posts
 inderes forum activity 74         # posting volume over time (momentum)
 inderes forum momentum           # rank ALL cached topics by momentum
@@ -59,11 +57,11 @@ inderes forum clear <id>         # drop one cached topic (--all to wipe)
 inderes forum db-path             # path to the local SQLite cache
 ```
 
-Add `--json` for raw Discourse fields (`cooked` = post body HTML, `username`, `created_at`) when extracting post text for analysis. `forum topic` returns the **whole** thread, backed by a local SQLite read-through cache: only new posts are fetched each call, and the full thread is served from disk (first call on a huge thread is slow but resumable; re-run if interrupted). This is separate from the authenticated MCP tool `inderes call search-forum-topics`. Cached posts are queryable with `inderes forum query "<SQL>"` (read-only) — e.g. most active users on a stock, or posting volume over time.
+`forum search` wraps the `search-forum-topics` MCP tool (title match, max 10) and prints each thread's id so it feeds straight into `forum topic <id>`. `forum topic` pulls the **whole** thread via the `get-forum-posts` tool into a local SQLite read-through cache: only new posts are fetched each call (resumable — re-run if interrupted), and the full thread is served from disk. Add `--json` for the raw fields (`cooked` = markdown body, `username`, `created_at`, plus `url`/`score`/`reply_count` in `raw`). A thread opened by bare id shows as `(untitled)` — the server returns no thread title; the title appears in `forum search` results. Cached posts are queryable with `inderes forum query "<SQL>"` (read-only) — e.g. most active users on a stock, or posting volume over time.
 
 ## Analyzing cached threads (you reason, the CLI only serves data)
 
-The cache has a clean-text `text` column (HTML stripped) — query `text`, not `cooked`, to save tokens. Cache a topic first with `inderes forum topic <id>`, then:
+The cache has a clean-text `text` column — query `text` for post bodies. Cache a topic first with `inderes forum topic <id>`, then:
 
 - **Catch me up** (recent posts): `inderes --json forum query "SELECT post_number, username, date(created_at) d, text FROM posts WHERE topic_id=74 ORDER BY post_number DESC LIMIT 40"` → summarize the result yourself.
 - **Summarize a long thread** (map-reduce — a big thread won't fit in context): pull it in chunks, summarize each, then combine. Get the size with `SELECT MAX(post_number) FROM posts WHERE topic_id=74`, then `... WHERE topic_id=74 AND post_number BETWEEN 1 AND 500 ORDER BY post_number` (repeat for 501–1000, …).

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -26,7 +26,6 @@ fn isolated() -> (Command, TempDir) {
     cmd.env_remove("INDERES_IDP_TOKEN_URL");
     cmd.env_remove("INDERES_IDP_USERINFO_URL");
     cmd.env_remove("INDERES_IDP_CLIENT_ID");
-    cmd.env_remove("INDERES_FORUM_URL");
     cmd.env_remove("INDERES_FORUM_DB");
     (cmd, tmp)
 }
@@ -69,7 +68,7 @@ fn help_lists_all_subcommands() {
 fn forum_help_lists_subcommands() {
     let (mut cmd, _tmp) = isolated();
     let mut assertion = cmd.args(["forum", "--help"]).assert().success();
-    for sub in ["search", "topic", "latest", "categories"] {
+    for sub in ["search", "topic", "query", "momentum", "refresh-all"] {
         assertion = assertion.stdout(predicate::str::contains(sub));
     }
 }


### PR DESCRIPTION
## What

Route `inderes forum` through the hosted MCP server's `get-forum-posts` and `search-forum-topics` tools instead of scraping `forum.inderes.com`'s public Discourse JSON API. Forum reads now require `inderes login`, like every other subcommand.

## Why

The MCP server already exposes `get-forum-posts` (full-thread reader) and `search-forum-topics` — the CLI was maintaining a separate anonymous Discourse client to do the same job. Going through MCP removes that second code path and survives the forum ever flipping to `login_required` (the server reads it server-side).

## Changes

- **`forum.rs`**: drop the Discourse HTTP `ForumClient`; add pure, unit-tested helpers — MCP post → cache-row mapping, cursor-paginated page parsing, and a search renderer that extracts the topic id from each result URL.
- **`cache.rs`**: replace the page-number watermark (`last_page`) with a resume `cursor` (forward Relay pagination). Auto-migrated — the column is added and existing posts are kept.
- **`commands.rs`**: cursor-based forward fetch loop calling `get-forum-posts`; `forum search` via `search-forum-topics`. Graceful cached-serve on a mid-walk error.
- Drop `forum latest` and `forum categories` (no MCP equivalent).
- Update the three skills, README, and the forum-auth memory.

## Known downgrades (accepted)

- `forum search` is now title-only, max 10 (Discourse `/search.json` also searched post bodies).
- A thread opened by bare id lists as `(untitled)` — `get-forum-posts` returns no thread title; the title shows in `forum search` results.
- Post bodies arrive as markdown (stored in `cooked`/`text`), not Discourse HTML.

## Verification

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-targets` (161 tests), markdownlint — all clean.
- Manual e2e against the live server: search → multi-page topic fetch (246 posts) → incremental re-run (0 new) → `--json`/SQL over cached rows → momentum/refresh-all.