### PR TITLE
docs: README accuracy after forum→MCP migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ inderes documents read <documentId> -s 1,2,5
 
 ### The 16-tool escape hatch
 
-Friendly subcommands cover ~half of Inderes's MCP surface. For the rest:
+Friendly subcommands cover 10 of Inderes's 16 MCP tools. For the rest:
 
 ```bash
 inderes call --list                                       # see all tools
 inderes call list-transcripts --arg companyId=COMPANY:200
-inderes call search-forum-topics --arg text=Nokia --arg order=relevancy
+inderes call list-insider-transactions --arg companyId=COMPANY:200
 inderes call list-calendar-events --arg 'regions=["FINLAND","SWEDEN"]'
 inderes call get-model-portfolio-content
 ```

--- a/README.md
+++ b/README.md
@@ -246,11 +246,16 @@ Written atomically (tempfile + rename) so a crash can't leave a half-written fil
         │                    │
         ▼                    ▼
      SKILL.md ──shells──▶ inderes ──OAuth──▶ sso.inderes.fi (Keycloak)
-                             │
-                             │ Bearer + JSON-RPC
-                             ▼
-                        mcp.inderes.com  (Streamable-HTTP MCP)
+                          │  │
+       forum-cache.db ◀───┘  │ Bearer + JSON-RPC
+      (SQLite, local         ▼
+       read-through)    mcp.inderes.com  (Streamable-HTTP MCP)
 ```
+
+`inderes forum` reads through `mcp.inderes.com` like every other command.
+`get-forum-posts` thread posts are persisted to the local `forum-cache.db`
+so a thread is downloaded once and then served and queried from disk;
+`search-forum-topics` results stay live and are never cached.
 
 - `src/oauth.rs` — PKCE S256, loopback redirect on ephemeral port, refresh grant.
 - `src/storage.rs` — atomic-rename JSON file at the platform config dir (0600 on Unix).


### PR DESCRIPTION
README updates following the forum→MCP migration (#29/#30):

1. **Architecture diagram** — add the local `forum-cache.db` (SQLite read-through cache) as a second on-disk store alongside `tokens.json`, with a note that `get-forum-posts` posts are cached while `search-forum-topics` stays live.
2. **Tool-coverage count** — friendly subcommands now wrap `search-forum-topics` + `get-forum-posts`, so coverage is **10 of 16** (was "~half").
3. **Escape-hatch example** — drop `inderes call search-forum-topics` (now covered by `inderes forum search`); use `list-insider-transactions` instead.

Docs-only; no code change. markdownlint + local `codex review` clean.